### PR TITLE
Add doctrine relation between ContentDimension and Dimension

### DIFF
--- a/Content/Application/ContentDimensionLoader/ContentDimensionLoaderInterface.php
+++ b/Content/Application/ContentDimensionLoader/ContentDimensionLoaderInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Content\Application\ContentDimensionLoader;
+
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentDimensionCollectionInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionCollectionInterface;
+
+interface ContentDimensionLoaderInterface
+{
+    public function load(
+        ContentInterface $content,
+        DimensionCollectionInterface $collection
+    ): ContentDimensionCollectionInterface;
+}

--- a/Content/Domain/Model/ContentDimensionInterface.php
+++ b/Content/Domain/Model/ContentDimensionInterface.php
@@ -20,7 +20,7 @@ interface ContentDimensionInterface
      */
     public function getId();
 
-    public function getDimensionId(): string;
+    public function getDimension(): DimensionInterface;
 
     public function createViewInstance(): ContentViewInterface;
 }

--- a/Content/Domain/Model/ContentDimensionTrait.php
+++ b/Content/Domain/Model/ContentDimensionTrait.php
@@ -21,17 +21,17 @@ trait ContentDimensionTrait
     protected $id;
 
     /**
-     * @var string
+     * @var DimensionInterface
      */
-    protected $dimensionId;
+    protected $dimension;
 
     public function getId()
     {
         return $this->id;
     }
 
-    public function getDimensionId(): string
+    public function getDimension(): DimensionInterface
     {
-        return $this->dimensionId;
+        return $this->dimension;
     }
 }

--- a/Content/Domain/Model/ContentInterface.php
+++ b/Content/Domain/Model/ContentInterface.php
@@ -24,7 +24,7 @@ interface ContentInterface
      */
     public function getDimensions(): Collection;
 
-    public function createDimension(string $dimensionId): ContentDimensionInterface;
+    public function createDimension(DimensionInterface $dimension): ContentDimensionInterface;
 
     public function addDimension(ContentDimensionInterface $contentDimension): void;
 

--- a/Content/Infrastructure/Doctrine/ContentDimensionLoader.php
+++ b/Content/Infrastructure/Doctrine/ContentDimensionLoader.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Content\Infrastructure\Doctrine;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentDimensionLoader\ContentDimensionLoaderInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentDimensionCollection;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentDimensionCollectionInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentDimensionInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionCollectionInterface;
+
+class ContentDimensionLoader implements ContentDimensionLoaderInterface
+{
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    public function load(
+        ContentInterface $content,
+        DimensionCollectionInterface $collection
+    ): ContentDimensionCollectionInterface {
+        $classMetadata = $this->entityManager->getClassMetadata(\get_class($content));
+        $contentDimensionClass = $classMetadata->getAssociationMapping('dimensions')['targetEntity'];
+
+        $queryBuilder = $this->entityManager->createQueryBuilder()
+            ->from($contentDimensionClass, 'contentDimension')
+            ->select('contentDimension')
+            ->addSelect('dimension')
+            ->innerJoin('contentDimension.dimension', 'dimension');
+
+        $dimensionIds = $collection->getDimensionIds();
+
+        $queryBuilder->where($queryBuilder->expr()->in('dimension.id', $dimensionIds));
+
+        /** @var ContentDimensionInterface[] $contentDimensions */
+        $contentDimensions = [];
+
+        // Sort correctly ContentDimensions by given dimensionIds to merge them later correctly
+        /** @var ContentDimensionInterface $contentDimension */
+        foreach ($queryBuilder->getQuery()->getResult() as $contentDimension) {
+            $position = array_search($contentDimension->getDimension()->getId(), $dimensionIds, true);
+            $contentDimensions[$position] = $contentDimension;
+        }
+
+        ksort($contentDimensions);
+
+        return new ContentDimensionCollection($contentDimensions);
+    }
+}

--- a/Content/Infrastructure/Doctrine/DimensionRepository.php
+++ b/Content/Infrastructure/Doctrine/DimensionRepository.php
@@ -65,7 +65,6 @@ class DimensionRepository implements DimensionRepositoryInterface
     public function add(DimensionInterface $dimension): void
     {
         $this->entityManager->persist($dimension);
-        $this->entityManager->flush($dimension); // TODO REMOVE this when moving Dimension to Content
     }
 
     public function findByAttributes(array $attributes): DimensionCollectionInterface

--- a/Resources/config/handlers.xml
+++ b/Resources/config/handlers.xml
@@ -17,6 +17,7 @@
 
         <service id="sulu_content.load_content_dimension_handler" class="Sulu\Bundle\ContentBundle\Content\Application\MessageHandler\LoadContentMessageHandler">
             <argument type="service" id="sulu.repository.dimension"/>
+            <argument type="service" id="sulu_content.content_dimension_loader"/>
             <argument type="service" id="sulu_content.view_factory"/>
             <argument type="service" id="sulu_content.api_view_resolver"/>
         </service>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -46,9 +46,17 @@
 
         <!-- Content Dimension Factory -->
         <service id="sulu_content.content_dimension_factory" class="Sulu\Bundle\ContentBundle\Content\Application\ContentDimensionFactory\ContentDimensionCollectionFactory">
+            <argument type="service" id="sulu_content.content_dimension_loader"/>
             <argument type="tagged" tag="sulu_content.content_dimension_mapper"/>
         </service>
 
-        <service id="ContentDimensionCollectionFactoryInterface" alias="sulu_content.content_dimension_factory"/>
+        <service id="Sulu\Bundle\ContentBundle\Content\Domain\Factory\ContentDimensionCollectionFactoryInterface" alias="sulu_content.content_dimension_factory"/>
+
+        <!-- Content Dimension Loader -->
+        <service id="sulu_content.content_dimension_loader" class="Sulu\Bundle\ContentBundle\Content\Infrastructure\Doctrine\ContentDimensionLoader">
+            <argument type="service" id="doctrine.orm.entity_manager"/>
+        </service>
+
+        <service id="Sulu\Bundle\ContentBundle\Content\Application\ContentDimensionLoader\ContentDimensionLoaderInterface" alias="sulu_content.content_dimension_loader"/>
     </services>
 </container>

--- a/TestCases/Content/ContentDimensionTestCaseTrait.php
+++ b/TestCases/Content/ContentDimensionTestCaseTrait.php
@@ -28,9 +28,9 @@ trait ContentDimensionTestCaseTrait
         $this->assertSame(1, $model->getId());
     }
 
-    public function testGetDimensionId(): void
+    public function testGetDimension(): void
     {
         $model = $this->getContentDimensionInstance();
-        $this->assertSame('123-456', $model->getDimensionId());
+        $this->assertSame('123-456', $model->getDimension()->getId());
     }
 }

--- a/Tests/Application/ExampleTestBundle/Controller/ExampleController.php
+++ b/Tests/Application/ExampleTestBundle/Controller/ExampleController.php
@@ -118,6 +118,7 @@ class ExampleController extends AbstractRestController implements ClassResourceI
 
         $this->entityManager->persist($example);
         $this->entityManager->flush();
+
         $contentView['id'] = $example->getId(); // TODO autoincrement id need to be set manually
 
         return $this->handleView($this->view($contentView, 201));

--- a/Tests/Application/ExampleTestBundle/Entity/Example.php
+++ b/Tests/Application/ExampleTestBundle/Entity/Example.php
@@ -15,6 +15,7 @@ namespace Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity;
 
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\AbstractContent;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentDimensionInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionInterface;
 
 class Example extends AbstractContent
 {
@@ -39,8 +40,8 @@ class Example extends AbstractContent
         return self::RESOURCE_KEY;
     }
 
-    public function createDimension(string $dimensionId): ContentDimensionInterface
+    public function createDimension(DimensionInterface $dimension): ContentDimensionInterface
     {
-        return new ExampleDimension($this, $dimensionId);
+        return new ExampleDimension($this, $dimension);
     }
 }

--- a/Tests/Application/ExampleTestBundle/Entity/ExampleDimension.php
+++ b/Tests/Application/ExampleTestBundle/Entity/ExampleDimension.php
@@ -15,6 +15,7 @@ namespace Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity;
 
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\AbstractContentDimension;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentViewInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ExcerptInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ExcerptTrait;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\SeoInterface;
@@ -41,10 +42,10 @@ class ExampleDimension extends AbstractContentDimension implements ExcerptInterf
      */
     protected $title;
 
-    public function __construct(Example $example, string $dimensionId)
+    public function __construct(Example $example, DimensionInterface $dimension)
     {
         $this->example = $example;
-        $this->dimensionId = $dimensionId;
+        $this->dimension = $dimension;
     }
 
     public function getExample(): Example
@@ -79,7 +80,7 @@ class ExampleDimension extends AbstractContentDimension implements ExcerptInterf
 
     public function createViewInstance(): ContentViewInterface
     {
-        $contentView = new ExampleView($this->getExample(), $this->dimensionId);
+        $contentView = new ExampleView($this->getExample(), $this->dimension);
         $contentView->setTitle($this->getTitle());
 
         return $contentView;

--- a/Tests/Application/ExampleTestBundle/Entity/ExampleView.php
+++ b/Tests/Application/ExampleTestBundle/Entity/ExampleView.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity;
 
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\AbstractContentView;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ExcerptInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ExcerptTrait;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\SeoInterface;
@@ -37,15 +38,10 @@ class ExampleView extends AbstractContentView implements SeoInterface, ExcerptIn
      */
     protected $title;
 
-    /**
-     * @var string
-     */
-    protected $dimensionId;
-
-    public function __construct(Example $example, string $dimensionId)
+    public function __construct(Example $example, DimensionInterface $dimension)
     {
         $this->example = $example;
-        $this->dimensionId = $dimensionId;
+        $this->dimensionId = $dimension->getId();
     }
 
     public function getContentId()

--- a/Tests/Application/ExampleTestBundle/Resources/config/doctrine/ExampleDimension.orm.xml
+++ b/Tests/Application/ExampleTestBundle/Resources/config/doctrine/ExampleDimension.orm.xml
@@ -8,7 +8,7 @@
             <generator strategy="AUTO"/>
         </id>
 
-        <field name="title" type="string" column="name" length="64" nullable="true"/>
+        <field name="title" type="string" column="title" length="64" nullable="true"/>
 
         <many-to-one field="example" target-entity="Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\Example" inversed-by="dimensions">
             <join-columns>

--- a/Tests/Functional/Content/Infrastructure/Doctrine/ContentDimensionLoaderTest.php
+++ b/Tests/Functional/Content/Infrastructure/Doctrine/ContentDimensionLoaderTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Tests\Functional\Content\Infrastructure\Doctrine;
+
+use Sulu\Bundle\ContentBundle\Content\Application\ContentDimensionLoader\ContentDimensionLoaderInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentDimensionInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\Dimension;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionCollection;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionInterface;
+use Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\Example;
+use Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\ExampleDimension;
+use Sulu\Bundle\ContentBundle\Tests\Functional\BaseTestCase;
+
+class ContentDimensionLoaderTest extends BaseTestCase
+{
+    public function setUp(): void
+    {
+        self::bootKernel();
+        self::purgeDatabase();
+    }
+
+    public function createContentDimensionLoader(): ContentDimensionLoaderInterface
+    {
+        return self::$container->get('sulu_content.content_dimension_loader');
+    }
+
+    public function testLoadExistAll(): void
+    {
+        $attributes = ['locale' => 'de'];
+
+        $dimension1 = $this->createDimension('123-456', []);
+        $dimension2 = $this->createDimension('456-789', ['locale' => 'de']);
+        $dimension3 = $this->createDimension('789-456', ['locale' => 'en']);
+
+        $content = $this->createContent();
+        $contentDimension1 = $this->createContentDimension($content, $dimension1);
+        $contentDimension2 = $this->createContentDimension($content, $dimension2);
+        $this->createContentDimension($content, $dimension3);
+
+        $dimensionCollection = new DimensionCollection($attributes, [
+            $dimension1,
+            $dimension2,
+        ]);
+
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
+
+        $contentDimensionLoader = $this->createContentDimensionLoader();
+        $contentDimensionCollection = $contentDimensionLoader->load($content, $dimensionCollection);
+
+        $this->assertCount(2, $contentDimensionCollection);
+
+        $this->assertSame([
+            $contentDimension1->getId(),
+            $contentDimension2->getId(),
+        ], array_map(function (ContentDimensionInterface $contentDimension) {
+            return $contentDimension->getId();
+        }, iterator_to_array($contentDimensionCollection)));
+    }
+
+    public function testLoadOneNotExist(): void
+    {
+        $attributes = ['locale' => 'de'];
+
+        $dimension1 = $this->createDimension('123-456', []);
+        $dimension2 = $this->createDimension('456-789', ['locale' => 'de']);
+
+        $content = $this->createContent();
+        $contentDimension1 = $this->createContentDimension($content, $dimension1);
+
+        $dimensionCollection = new DimensionCollection($attributes, [
+            $dimension1,
+            $dimension2,
+        ]);
+
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
+
+        $contentDimensionLoader = $this->createContentDimensionLoader();
+        $contentDimensionCollection = $contentDimensionLoader->load($content, $dimensionCollection);
+
+        $this->assertCount(1, $contentDimensionCollection);
+
+        $this->assertSame([
+            $contentDimension1->getId(),
+        ], array_map(function (ContentDimensionInterface $contentDimension) {
+            return $contentDimension->getId();
+        }, iterator_to_array($contentDimensionCollection)));
+    }
+
+    public function testLoadExistOrderedDifferent(): void
+    {
+        $attributes = ['locale' => 'de'];
+
+        $dimension1 = $this->createDimension('123-456', []);
+        $dimension2 = $this->createDimension('456-789', ['locale' => 'de']);
+
+        $content = $this->createContent();
+        // First create the dimension 2 to test if its still the last dimension
+        $contentDimension2 = $this->createContentDimension($content, $dimension2);
+        $contentDimension1 = $this->createContentDimension($content, $dimension1);
+
+        $dimensionCollection = new DimensionCollection($attributes, [
+            $dimension1,
+            $dimension2,
+        ]);
+
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
+
+        $contentDimensionLoader = $this->createContentDimensionLoader();
+        $contentDimensionCollection = $contentDimensionLoader->load($content, $dimensionCollection);
+
+        $this->assertCount(2, $contentDimensionCollection);
+
+        $this->assertSame([
+            $contentDimension1->getId(),
+            $contentDimension2->getId(), // Dimension 2 should be the last one in this case
+        ], array_map(function (ContentDimensionInterface $contentDimension) {
+            return $contentDimension->getId();
+        }, iterator_to_array($contentDimensionCollection)));
+    }
+
+    /**
+     * @param mixed[] $attributes
+     */
+    private function createDimension(string $id, array $attributes): DimensionInterface
+    {
+        $dimension = new Dimension($id, $attributes);
+        $this->getEntityManager()->persist($dimension);
+
+        return $dimension;
+    }
+
+    private function createContent(): Example
+    {
+        $example = new Example();
+        $this->getEntityManager()->persist($example);
+
+        return $example;
+    }
+
+    private function createContentDimension(Example $example, DimensionInterface $dimension): ExampleDimension
+    {
+        $exampleDimension = new ExampleDimension($example, $dimension);
+        $this->getEntityManager()->persist($exampleDimension);
+
+        return $exampleDimension;
+    }
+}

--- a/Tests/Unit/Content/Application/Message/LoadContentMessageTest.php
+++ b/Tests/Unit/Content/Application/Message/LoadContentMessageTest.php
@@ -18,6 +18,7 @@ use Sulu\Bundle\ContentBundle\Content\Application\Message\LoadContentMessage;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\AbstractContent;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentDimensionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionInterface;
 
 class LoadContentMessageTest extends TestCase
 {
@@ -39,7 +40,7 @@ class LoadContentMessageTest extends TestCase
                 return 'example';
             }
 
-            public function createDimension(string $dimensionId): ContentDimensionInterface
+            public function createDimension(DimensionInterface $dimension): ContentDimensionInterface
             {
                 throw new \RuntimeException('Should not be called');
             }

--- a/Tests/Unit/Content/Application/Message/SaveContentMessageTest.php
+++ b/Tests/Unit/Content/Application/Message/SaveContentMessageTest.php
@@ -18,6 +18,7 @@ use Sulu\Bundle\ContentBundle\Content\Application\Message\SaveContentMessage;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\AbstractContent;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentDimensionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionInterface;
 
 class SaveContentMessageTest extends TestCase
 {
@@ -41,7 +42,7 @@ class SaveContentMessageTest extends TestCase
                 return 'example';
             }
 
-            public function createDimension(string $dimensionId): ContentDimensionInterface
+            public function createDimension(DimensionInterface $dimension): ContentDimensionInterface
             {
                 throw new \RuntimeException('Should not be called');
             }

--- a/Tests/Unit/Content/Application/MessageHandler/SaveContentMessageHandlerTest.php
+++ b/Tests/Unit/Content/Application/MessageHandler/SaveContentMessageHandlerTest.php
@@ -27,6 +27,7 @@ use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentViewInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\Dimension;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionCollection;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionInterface;
 
 class SaveContentMessageHandlerTest extends TestCase
 {
@@ -52,7 +53,7 @@ class SaveContentMessageHandlerTest extends TestCase
                 return 'example';
             }
 
-            public function createDimension(string $dimensionId): ContentDimensionInterface
+            public function createDimension(DimensionInterface $dimension): ContentDimensionInterface
             {
                 throw new \RuntimeException('Should not be called in a unit test.');
             }

--- a/Tests/Unit/Content/Domain/Model/ContentDimensionTest.php
+++ b/Tests/Unit/Content/Domain/Model/ContentDimensionTest.php
@@ -18,6 +18,8 @@ use Sulu\Bundle\ContentBundle\Content\Domain\Model\AbstractContentDimension;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\AbstractContentView;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentDimensionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentViewInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\Dimension;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionInterface;
 use Sulu\Bundle\ContentBundle\TestCases\Content\ContentDimensionTestCaseTrait;
 
 class ContentDimensionTest extends TestCase
@@ -26,9 +28,15 @@ class ContentDimensionTest extends TestCase
 
     protected function getContentDimensionInstance(): ContentDimensionInterface
     {
-        return new class() extends AbstractContentDimension {
+        $dimension = new Dimension('123-456');
+
+        return new class($dimension) extends AbstractContentDimension {
             protected $id = 1;
-            protected $dimensionId = '123-456';
+
+            public function __construct(DimensionInterface $dimension)
+            {
+                $this->dimension = $dimension;
+            }
 
             public function createViewInstance(): ContentViewInterface
             {

--- a/Tests/Unit/Content/Domain/Model/ContentTest.php
+++ b/Tests/Unit/Content/Domain/Model/ContentTest.php
@@ -19,6 +19,7 @@ use Sulu\Bundle\ContentBundle\Content\Domain\Model\AbstractContentDimension;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\AbstractContentView;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentDimensionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentViewInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ExcerptInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ExcerptTrait;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\SeoInterface;
@@ -39,7 +40,7 @@ class ContentTest extends TestCase
                 return 'example';
             }
 
-            public function createDimension(string $dimensionId): ContentDimensionInterface
+            public function createDimension(DimensionInterface $dimension): ContentDimensionInterface
             {
                 throw new \RuntimeException();
             }

--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
             "@phpunit"
         ],
         "test-coverage": "@phpunit --coverage-php Tests/reports/coverage.php --coverage-html Tests/reports/html --log-junit Tests/reports/unit/junit.xml",
-        "test-coverage-checker": "@php vendor/bin/code-coverage-checker \"Tests/reports/coverage.php\" \"line\" \"96.00\"",
+        "test-coverage-checker": "@php vendor/bin/code-coverage-checker \"Tests/reports/coverage.php\" \"line\" \"99.00\"",
         "test-unit": "@phpunit Tests/Unit",
         "test-unit-coverage": "@phpunit Tests/Unit --coverage-php Tests/reports/coverage.php --coverage-html Tests/reports/html --log-junit Tests/reports/unit/junit.xml",
         "test-unit-coverage-checker": "@php Tests/coverage-checker.php \"line\" \"96.00\" \"Dimension/Domain\" \"Content/Domain\"",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -24,3 +24,7 @@ parameters:
     autoload_files:
         - vendor/bin/.phpunit/phpunit-8/vendor/autoload.php
         - vendor/autoload.php
+    ignoreErrors:
+        # See https://github.com/phpstan/phpstan/issues/2600
+        - message: '#Parameter \#1 \$x of method Doctrine\\Common\\Collections\\ExpressionBuilder::orX\(\) expects array<int,mixed>|null, Doctrine\\Common\\Collections\\Expr\\Comparison given\.#'
+          path: %currentWorkingDirectory%/Content/Infrastructure/Doctrine/DimensionRepository.php


### PR DESCRIPTION
There are cases where we need to access from the `$contentDimension` e.g. the `locale` attributes. That we don't have duplicated data we go here with `$contentDimesion->getDimension()->getLocale()`.

fixes #39 