### PR TITLE
WIP: Add workflow process with publishing

### DIFF
--- a/Content/Application/Message/CopyContentDimensionMessage.php
+++ b/Content/Application/Message/CopyContentDimensionMessage.php
@@ -15,7 +15,7 @@ namespace Sulu\Bundle\ContentBundle\Content\Application\Message;
 
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentInterface;
 
-class WorkflowTransitionContentMessage
+class CopyContentDimensionMessage
 {
     /**
      * @var ContentInterface
@@ -25,21 +25,22 @@ class WorkflowTransitionContentMessage
     /**
      * @var mixed[]
      */
-    private $dimensionAttributes;
+    private $fromDimensionAttributes;
 
     /**
      * @var string
      */
-    private $toWorkflowStage;
+    private $toDimensionAttributes;
 
     /**
-     * @param mixed[] $dimensionAttributes
+     * @param mixed[] $fromDimensionAttributes
+     * @param mixed[] $toDimensionAttributes
      */
-    public function __construct(ContentInterface $content, array $dimensionAttributes, string $toWorkflowStage)
+    public function __construct(ContentInterface $content, array $fromDimensionAttributes, array $toDimensionAttributes)
     {
         $this->content = $content;
-        $this->dimensionAttributes = $dimensionAttributes;
-        $this->toWorkflowStage = $toWorkflowStage;
+        $this->fromDimensionAttributes = $fromDimensionAttributes;
+        $this->toDimensionAttributes = $toDimensionAttributes;
     }
 
     public function getContent(): ContentInterface
@@ -50,13 +51,16 @@ class WorkflowTransitionContentMessage
     /**
      * @return mixed[]
      */
-    public function getDimensionAttributes(): array
+    public function getFromDimensionAttributes(): array
     {
-        return $this->dimensionAttributes;
+        return $this->fromDimensionAttributes;
     }
 
-    public function getToWorkflowStage(): string
+    /**
+     * @return mixed[]
+     */
+    public function getToDimensionAttributes(): array
     {
-        return $this->toWorkflowStage;
+        return $this->toDimensionAttributes;
     }
 }

--- a/Content/Application/Message/WorkflowTransitionContentMessage.php
+++ b/Content/Application/Message/WorkflowTransitionContentMessage.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Content\Application\Message;
+
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentInterface;
+
+class WorkflowTransitionContentMessage
+{
+    /**
+     * @var ContentInterface
+     */
+    private $content;
+
+    /**
+     * @var mixed[]
+     */
+    private $dimensionAttributes;
+
+    /**
+     * @var string
+     */
+    private $workflowStage;
+
+    /**
+     * @param mixed[] $dimensionAttributes
+     */
+    public function __construct(ContentInterface $content, array $dimensionAttributes, string $workflowStage)
+    {
+        $this->content = $content;
+        $this->dimensionAttributes = $dimensionAttributes;
+        $this->workflowStage = $workflowStage;
+    }
+
+    public function getContent(): ContentInterface
+    {
+        return $this->content;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getDimensionAttributes(): array
+    {
+        return $this->dimensionAttributes;
+    }
+
+    public function getWorkflowStage(): string
+    {
+        return $this->workflowStage;
+    }
+}

--- a/Content/Application/MessageHandler/CopyContentDimensionMessageHandler.php
+++ b/Content/Application/MessageHandler/CopyContentDimensionMessageHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Content\Application\MessageHandler;
+
+use Sulu\Bundle\ContentBundle\Content\Application\Message\CopyContentDimensionMessage;
+use Sulu\Bundle\ContentBundle\Content\Application\Message\LoadContentMessage;
+use Sulu\Bundle\ContentBundle\Content\Application\Message\SaveContentMessage;
+use Symfony\Component\Messenger\HandleTrait;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+class CopyContentDimensionMessageHandler
+{
+    use HandleTrait;
+
+    /**
+     * @var MessageBusInterface
+     */
+    private $suluContentMessageBus;
+
+    public function __construct(
+        MessageBusInterface $suluContentMessageBus
+    ) {
+        $this->messageBus = $suluContentMessageBus;
+    }
+
+    public function __invoke(CopyContentDimensionMessage $message): array
+    {
+        $content = $message->getContent();
+        $data = $this->handle(
+            new LoadContentMessage($content, $message->getFromDimensionAttributes())
+        );
+
+        return $this->handle(
+            new SaveContentMessage($content, $data, $message->getToDimensionAttributes())
+        );
+    }
+}

--- a/Content/Application/MessageHandler/WorkflowTransitionContentMessageHandler.php
+++ b/Content/Application/MessageHandler/WorkflowTransitionContentMessageHandler.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Content\Application\MessageHandler;
+
+use Sulu\Bundle\ContentBundle\Content\Application\Message\CopyContentDimensionMessage;
+use Sulu\Bundle\ContentBundle\Content\Application\Message\WorkflowTransitionContentMessage;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Repository\DimensionRepositoryInterface;
+use Symfony\Component\Messenger\HandleTrait;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+class WorkflowTransitionContentMessageHandler
+{
+    use HandleTrait;
+
+    /**
+     * @var DimensionRepositoryInterface
+     */
+    private $dimensionRepository;
+
+    /**
+     * @var MessageBusInterface
+     */
+    private $suluContentMessageBus;
+
+    public function __construct(
+        DimensionRepositoryInterface $dimensionRepository,
+        MessageBusInterface $suluContentMessageBus
+    ) {
+        $this->dimensionRepository = $dimensionRepository;
+        $this->messageBus = $suluContentMessageBus;
+    }
+
+    public function __invoke(WorkflowTransitionContentMessage $message): array
+    {
+        $content = $message->getContent();
+        $fromDimensionAttributes = $message->getDimensionAttributes();
+        $dummyDimension = $this->dimensionRepository->create('dummy', $fromDimensionAttributes);
+        $fromWorkflowStage = $dummyDimension->getWorkflowStage();
+
+        $toDimensionAttributes = $fromDimensionAttributes;
+        $toWorkflowStage = $message->getToWorkflowStage();
+        $toDimensionAttributes['workflowStage'] = $toWorkflowStage;
+
+        // TODO use workflow component?
+        if (DimensionInterface::WORKFLOW_STAGE_DRAFT !== $fromWorkflowStage) {
+            throw new \LogicException(sprintf('Can not transform from "%s" to "%s".', $fromWorkflowStage, $toWorkflowStage));
+        }
+
+        if (DimensionInterface::WORKFLOW_STAGE_LIVE !== $toWorkflowStage) {
+            throw new \LogicException(sprintf('Can not transform from "%s" to "%s".', $fromWorkflowStage, $toWorkflowStage));
+        }
+
+        return $this->handle(
+            new CopyContentDimensionMessage($content, $fromDimensionAttributes, $toDimensionAttributes)
+        );
+    }
+}

--- a/Resources/config/handlers.xml
+++ b/Resources/config/handlers.xml
@@ -22,6 +22,15 @@
             <argument type="service" id="sulu_content.api_view_resolver"/>
         </service>
 
+        <service id="sulu_content.workflow_transition_content_handler" class="Sulu\Bundle\ContentBundle\Content\Application\MessageHandler\WorkflowTransitionContentMessageHandler">
+            <argument type="service" id="sulu.repository.dimension"/>
+            <argument type="service" id="sulu_content.message_bus"/>
+        </service>
+
+        <service id="sulu_content.copy_content_dimension_handler" class="Sulu\Bundle\ContentBundle\Content\Application\MessageHandler\CopyContentDimensionMessageHandler">
+            <argument type="service" id="sulu_content.message_bus"/>
+        </service>
+
         <service id="sulu_content.load_content_view_dimension_handler" class="Sulu\Bundle\ContentBundle\Content\Application\MessageHandler\LoadContentViewMessageHandler">
             <argument type="service" id="sulu.repository.dimension"/>
             <argument type="service" id="sulu_content.content_dimension_loader"/>

--- a/Tests/Unit/Content/Application/Message/WorkflowTransitionContentMessageTest.php
+++ b/Tests/Unit/Content/Application/Message/WorkflowTransitionContentMessageTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Tests\Unit\Content\Application\Message;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\ContentBundle\Content\Application\Message\WorkflowTransitionContentMessage;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\AbstractContent;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentDimensionInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionInterface;
+
+class WorkflowTransitionContentMessageTest extends TestCase
+{
+    /**
+     * @param mixed[] $dimensionAttributes
+     */
+    protected function createWorkflowTransitionContentMessage(
+        ContentInterface $content,
+        array $dimensionAttributes,
+        string $workflowStage
+    ): WorkflowTransitionContentMessage {
+        return new WorkflowTransitionContentMessage($content, $dimensionAttributes, $workflowStage);
+    }
+
+    protected function createContentInstance(): ContentInterface
+    {
+        return new class() extends AbstractContent {
+            public static function getResourceKey(): string
+            {
+                return 'example';
+            }
+
+            public function createDimension(DimensionInterface $dimension): ContentDimensionInterface
+            {
+                throw new \RuntimeException('Should not be called');
+            }
+
+            public function getId()
+            {
+                return null;
+            }
+        };
+    }
+
+    public function testGetContent(): void
+    {
+        $content = $this->createContentInstance();
+        $message = $this->createWorkflowTransitionContentMessage($content, [], 'live');
+
+        $this->assertSame($content, $message->getContent());
+    }
+
+    public function testGetDimensionAttributes(): void
+    {
+        $content = $this->createContentInstance();
+        $message = $this->createWorkflowTransitionContentMessage($content, [
+            'locale' => 'de',
+        ], 'live');
+
+        $this->assertSame([
+            'locale' => 'de',
+        ], $message->getDimensionAttributes());
+    }
+
+    public function testGetWorkflowStage(): void
+    {
+        $content = $this->createContentInstance();
+        $message = $this->createWorkflowTransitionContentMessage($content, [
+            'locale' => 'de',
+        ], 'live');
+
+        $this->assertSame('live', $message->getWorkflowStage());
+    }
+}

--- a/Tests/Unit/Content/Application/Message/WorkflowTransitionContentMessageTest.php
+++ b/Tests/Unit/Content/Application/Message/WorkflowTransitionContentMessageTest.php
@@ -73,13 +73,13 @@ class WorkflowTransitionContentMessageTest extends TestCase
         ], $message->getDimensionAttributes());
     }
 
-    public function testGetWorkflowStage(): void
+    public function testGetToWorkflowStage(): void
     {
         $content = $this->createContentInstance();
         $message = $this->createWorkflowTransitionContentMessage($content, [
             'locale' => 'de',
         ], 'live');
 
-        $this->assertSame('live', $message->getWorkflowStage());
+        $this->assertSame('live', $message->getToWorkflowStage());
     }
 }


### PR DESCRIPTION
Entities should only be available when are published throwing a message to convert a draft into a published entity.

```php
$dimensionAttributes = ['workflowStage' => 'draft', 'locale' => 'en'];
new WorkflowTransitionContentMessage($example, $dimensionAttributes, 'live');
```

later it should be possible to add additional worflow stage e.g.:

```php
$dimensionAttributes = ['workflowStage' => 'draft', 'locale' => 'en'];
new WorkflowTransitionContentMessage($example, $dimensionAttributes, 'review');
// or
$dimensionAttributes = ['workflowStage' => 'review', 'locale' => 'en'];
new WorkflowTransitionContentMessage($example, $dimensionAttributes, 'live');
```