### PR TITLE
Rename Dimension workflowStage to stage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,6 @@ jobs:
             - attach_workspace:
                   at: .
             - run: php composer.phar info
-            - run: ls vendor/symfony/framework-bundle/
             - run: php composer.phar bootstrap-test-environment
             - run: php composer.phar lint
     test:

--- a/Content/Domain/Model/Dimension.php
+++ b/Content/Domain/Model/Dimension.php
@@ -35,7 +35,7 @@ class Dimension implements DimensionInterface
     /**
      * @var string
      */
-    private $workflowStage;
+    private $stage;
 
     /**
      * @param array<string, mixed> $attributes
@@ -47,7 +47,7 @@ class Dimension implements DimensionInterface
         $this->id = $id ?: Uuid::uuid4()->toString();
         $attributes = array_merge(static::getDefaultValues(), $attributes);
         $this->locale = $attributes['locale'];
-        $this->workflowStage = $attributes['workflowStage'];
+        $this->stage = $attributes['stage'];
     }
 
     public function getId(): string
@@ -60,16 +60,16 @@ class Dimension implements DimensionInterface
         return $this->locale;
     }
 
-    public function getWorkflowStage(): string
+    public function getStage(): string
     {
-        return $this->workflowStage;
+        return $this->stage;
     }
 
     public function getAttributes(): array
     {
         return [
             'locale' => $this->locale,
-            'workflowStage' => $this->workflowStage,
+            'stage' => $this->stage,
         ];
     }
 
@@ -77,7 +77,7 @@ class Dimension implements DimensionInterface
     {
         return [
             'locale' => null,
-            'workflowStage' => DimensionInterface::WORKFLOW_STAGE_DRAFT,
+            'stage' => DimensionInterface::STAGE_DRAFT,
         ];
     }
 }

--- a/Content/Domain/Model/DimensionInterface.php
+++ b/Content/Domain/Model/DimensionInterface.php
@@ -15,14 +15,14 @@ namespace Sulu\Bundle\ContentBundle\Content\Domain\Model;
 
 interface DimensionInterface
 {
-    const WORKFLOW_STAGE_DRAFT = 'draft';
-    const WORKFLOW_STAGE_LIVE = 'live';
+    const STAGE_DRAFT = 'draft';
+    const STAGE_LIVE = 'live';
 
     public function getId(): string;
 
     public function getLocale(): ?string;
 
-    public function getWorkflowStage(): string;
+    public function getStage(): string;
 
     /**
      * @return mixed[]

--- a/Content/Infrastructure/Sulu/Route/ContentRouteDefaultsProvider.php
+++ b/Content/Infrastructure/Sulu/Route/ContentRouteDefaultsProvider.php
@@ -108,10 +108,10 @@ class ContentRouteDefaultsProvider implements RouteDefaultsProviderInterface
         }
 
         try {
-            // FIXME use the live workflow-stage when publishing is implemented
+            // FIXME use the live stage when publishing is implemented
 
             return $this->handle(
-                new LoadContentViewMessage($content, ['locale' => $locale, 'workflowStage' => 'draft'])
+                new LoadContentViewMessage($content, ['locale' => $locale, 'stage' => 'draft'])
             );
         } catch (HandlerFailedException $exception) {
             return null;

--- a/Resources/config/doctrine/Dimension/Dimension.orm.xml
+++ b/Resources/config/doctrine/Dimension/Dimension.orm.xml
@@ -7,7 +7,7 @@
             table="cn_dimensions">
         <indexes>
             <index columns="locale"/>
-            <index columns="workflowStage"/>
+            <index columns="stage"/>
         </indexes>
 
         <id name="no" type="integer">
@@ -16,6 +16,6 @@
 
         <field name="id" type="guid" nullable="false" unique="true"/>
         <field name="locale" type="string" column="locale" length="5" nullable="true"/>
-        <field name="workflowStage" type="string" column="workflowStage" length="16"/>
+        <field name="stage" type="string" column="stage" length="16"/>
     </mapped-superclass>
 </doctrine-mapping>

--- a/TestCases/Dimension/DimensionRepositoryTestCaseTrait.php
+++ b/TestCases/Dimension/DimensionRepositoryTestCaseTrait.php
@@ -111,17 +111,17 @@ trait DimensionRepositoryTestCaseTrait
         $dimension1 = $dimensionRepository->create(static::$TEST_ID, ['locale' => 'de']);
         $dimensionRepository->add($dimension1);
 
-        $dimension2 = $dimensionRepository->create(static::$TEST_ID2, ['locale' => 'de', 'workflowStage' => 'live']);
+        $dimension2 = $dimensionRepository->create(static::$TEST_ID2, ['locale' => 'de', 'stage' => 'live']);
         $dimensionRepository->add($dimension2);
 
-        $dimension3 = $dimensionRepository->create(static::$TEST_ID3, ['locale' => 'en', 'workflowStage' => 'draft']);
+        $dimension3 = $dimensionRepository->create(static::$TEST_ID3, ['locale' => 'en', 'stage' => 'draft']);
         $dimensionRepository->add($dimension3);
 
         if (!$skipSave) {
             static::saveData();
         }
 
-        $dimension = $dimensionRepository->findOneBy(['locale' => 'de', 'workflowStage' => 'draft']);
+        $dimension = $dimensionRepository->findOneBy(['locale' => 'de', 'stage' => 'draft']);
         $this->assertNotNull($dimension);
         $this->assertSame(static::$TEST_ID, $dimension->getId());
     }
@@ -142,10 +142,10 @@ trait DimensionRepositoryTestCaseTrait
         $dimension1 = $dimensionRepository->create(static::$TEST_ID, ['locale' => 'de']);
         $dimensionRepository->add($dimension1);
 
-        $dimension2 = $dimensionRepository->create(static::$TEST_ID2, ['locale' => 'de', 'workflowStage' => 'live']);
+        $dimension2 = $dimensionRepository->create(static::$TEST_ID2, ['locale' => 'de', 'stage' => 'live']);
         $dimensionRepository->add($dimension2);
 
-        $dimension3 = $dimensionRepository->create(static::$TEST_ID3, ['locale' => 'en', 'workflowStage' => 'draft']);
+        $dimension3 = $dimensionRepository->create(static::$TEST_ID3, ['locale' => 'en', 'stage' => 'draft']);
         $dimensionRepository->add($dimension3);
 
         if (!$skipSave) {
@@ -159,7 +159,7 @@ trait DimensionRepositoryTestCaseTrait
     /**
      * @dataProvider saveSkipDataProvider
      */
-    public function testFindAttributesWithLocaleAndWorkflowStage(bool $skipSave): void
+    public function testFindAttributesWithLocaleAndStage(bool $skipSave): void
     {
         if ($skipSave) {
             $this->markTestSkipped('Currently not implemented to findIdsByAttributes without saving.');
@@ -175,7 +175,7 @@ trait DimensionRepositoryTestCaseTrait
         $dimension2 = $dimensionRepository->create(static::$TEST_ID2, ['locale' => 'en-gb']);
         $dimensionRepository->add($dimension2);
 
-        $dimension3 = $dimensionRepository->create(static::$TEST_ID3, ['locale' => 'de', 'workflowStage' => 'live']);
+        $dimension3 = $dimensionRepository->create(static::$TEST_ID3, ['locale' => 'de', 'stage' => 'live']);
         $dimensionRepository->add($dimension3);
 
         $dimension4 = $dimensionRepository->create(static::$TEST_ID4);
@@ -187,7 +187,7 @@ trait DimensionRepositoryTestCaseTrait
 
         $dimensions = iterator_to_array($dimensionRepository->findByAttributes([
             'locale' => 'en',
-            'workflowStage' => DimensionInterface::WORKFLOW_STAGE_DRAFT,
+            'stage' => DimensionInterface::STAGE_DRAFT,
         ]));
 
         $this->assertCount(2, $dimensions);
@@ -199,7 +199,7 @@ trait DimensionRepositoryTestCaseTrait
     /**
      * @dataProvider saveSkipDataProvider
      */
-    public function testFindByAttributesWithWorkflowStageOnly(bool $skipSave): void
+    public function testFindByAttributesWithStageOnly(bool $skipSave): void
     {
         if ($skipSave) {
             $this->markTestSkipped('Currently not implemented to findByAttributes without saving.');
@@ -215,7 +215,7 @@ trait DimensionRepositoryTestCaseTrait
         $dimension2 = $dimensionRepository->create(static::$TEST_ID2, ['locale' => 'en-gb']);
         $dimensionRepository->add($dimension2);
 
-        $dimension3 = $dimensionRepository->create(static::$TEST_ID3, ['locale' => 'de', 'workflowStage' => 'live']);
+        $dimension3 = $dimensionRepository->create(static::$TEST_ID3, ['locale' => 'de', 'stage' => 'live']);
         $dimensionRepository->add($dimension3);
 
         $dimension4 = $dimensionRepository->create(static::$TEST_ID4);
@@ -226,7 +226,7 @@ trait DimensionRepositoryTestCaseTrait
         }
 
         $dimensions = iterator_to_array($dimensionRepository->findByAttributes([
-            'workflowStage' => DimensionInterface::WORKFLOW_STAGE_DRAFT,
+            'stage' => DimensionInterface::STAGE_DRAFT,
         ]));
 
         $this->assertCount(1, $dimensions);
@@ -254,7 +254,7 @@ trait DimensionRepositoryTestCaseTrait
         $dimension2 = $dimensionRepository->create(static::$TEST_ID2, ['locale' => 'en-gb']);
         $dimensionRepository->add($dimension2);
 
-        $dimension3 = $dimensionRepository->create(static::$TEST_ID3, ['locale' => 'en', 'workflowStage' => 'live']);
+        $dimension3 = $dimensionRepository->create(static::$TEST_ID3, ['locale' => 'en', 'stage' => 'live']);
         $dimensionRepository->add($dimension3);
 
         $dimension4 = $dimensionRepository->create(static::$TEST_ID4);

--- a/Tests/Application/ExampleTestBundle/Resources/config/lists/examples.xml
+++ b/Tests/Application/ExampleTestBundle/Resources/config/lists/examples.xml
@@ -14,7 +14,7 @@
     <joins name="dimension">
         <join>
             <entity-name>%sulu.model.dimension.class%</entity-name>
-            <condition>%sulu.model.dimension.class%.locale = :locale AND %sulu.model.dimension.class%.workflowStage = 'draft'</condition>
+            <condition>%sulu.model.dimension.class%.locale = :locale AND %sulu.model.dimension.class%.stage = 'draft'</condition>
         </join>
     </joins>
 

--- a/Tests/Unit/Content/Application/ContentDimensionFactory/ContentDimensionCollectionFactoryTest.php
+++ b/Tests/Unit/Content/Application/ContentDimensionFactory/ContentDimensionCollectionFactoryTest.php
@@ -53,7 +53,7 @@ class ContentDimensionCollectionFactoryTest extends TestCase
 
         $attributes = [
             'locale' => 'de',
-            'workflowStage' => 'draft',
+            'stage' => 'draft',
         ];
 
         $data = [
@@ -98,7 +98,7 @@ class ContentDimensionCollectionFactoryTest extends TestCase
 
         $attributes = [
             'locale' => 'de',
-            'workflowStage' => 'draft',
+            'stage' => 'draft',
         ];
 
         $data = [
@@ -138,7 +138,7 @@ class ContentDimensionCollectionFactoryTest extends TestCase
 
         $attributes = [
             'locale' => 'de',
-            'workflowStage' => 'draft',
+            'stage' => 'draft',
         ];
 
         $data = [
@@ -184,7 +184,7 @@ class ContentDimensionCollectionFactoryTest extends TestCase
 
         $attributes = [
             'locale' => 'de',
-            'workflowStage' => 'draft',
+            'stage' => 'draft',
         ];
 
         $data = [

--- a/Tests/Unit/Content/Domain/Factory/DimensionFactoryTest.php
+++ b/Tests/Unit/Content/Domain/Factory/DimensionFactoryTest.php
@@ -33,12 +33,12 @@ class DimensionFactoryTest extends TestCase
     {
         $localizedAttributes = [
             'locale' => 'de',
-            'workflowStage' => 'en',
+            'stage' => 'draft',
         ];
 
         $unlocalizedAttributes = [
             'locale' => null,
-            'workflowStage' => 'en',
+            'stage' => 'draft',
         ];
 
         $dimensionRepository = $this->prophesize(DimensionRepositoryInterface::class);
@@ -59,19 +59,19 @@ class DimensionFactoryTest extends TestCase
 
         $dimensionCollectionFactory = $this->getDimensionFactoryInstance($dimensionRepository->reveal());
 
-        $dimensionCollectionFactory->create(['locale' => 'de', 'workflowStage' => 'en']);
+        $dimensionCollectionFactory->create(['locale' => 'de', 'stage' => 'draft']);
     }
 
     public function testCreateExist(): void
     {
         $localizedAttributes = [
             'locale' => 'de',
-            'workflowStage' => 'en',
+            'stage' => 'draft',
         ];
 
         $unlocalizedAttributes = [
             'locale' => null,
-            'workflowStage' => 'en',
+            'stage' => 'draft',
         ];
 
         $localizedDimension = new Dimension(null, $localizedAttributes);
@@ -97,7 +97,7 @@ class DimensionFactoryTest extends TestCase
     {
         $unlocalizedAttributes = [
             'locale' => null,
-            'workflowStage' => 'en',
+            'stage' => 'draft',
         ];
 
         $dimensionRepository = $this->prophesize(DimensionRepositoryInterface::class);
@@ -120,7 +120,7 @@ class DimensionFactoryTest extends TestCase
     {
         $unlocalizedAttributes = [
             'locale' => null,
-            'workflowStage' => 'en',
+            'stage' => 'draft',
         ];
 
         $unlocalizedDimension = new Dimension(null, $unlocalizedAttributes);

--- a/Tests/Unit/Content/Domain/Model/DimensionCollectionTest.php
+++ b/Tests/Unit/Content/Domain/Model/DimensionCollectionTest.php
@@ -50,12 +50,12 @@ class DimensionCollectionTest extends TestCase
     {
         $dimensionCollection = $this->createDimensionCollection([
             'locale' => 'de',
-            'workflowStage' => 'draft',
+            'stage' => 'draft',
         ]);
 
         $this->assertSame([
             'locale' => 'de',
-            'workflowStage' => 'draft',
+            'stage' => 'draft',
         ], $dimensionCollection->getAttributes());
     }
 
@@ -63,7 +63,7 @@ class DimensionCollectionTest extends TestCase
     {
         $dimensionCollection = $this->createDimensionCollection([
             'locale' => 'de',
-            'workflowStage' => 'draft',
+            'stage' => 'draft',
         ], [
             $this->createDimension('123-456'),
             $this->createDimension('456-789', ['locale' => 'de']),
@@ -91,7 +91,7 @@ class DimensionCollectionTest extends TestCase
     {
         $dimensionCollection = $this->createDimensionCollection([
             'locale' => 'de',
-            'workflowStage' => 'draft',
+            'stage' => 'draft',
         ], [
             $unlocalizedDimension = $this->createDimension('123-456'),
             $this->createDimension('456-789', ['locale' => 'de']),
@@ -104,7 +104,7 @@ class DimensionCollectionTest extends TestCase
     {
         $dimensionCollection = $this->createDimensionCollection([
             'locale' => 'de',
-            'workflowStage' => 'draft',
+            'stage' => 'draft',
         ], [
             $this->createDimension('123-456'),
             $localizedDimdension = $this->createDimension('456-789', ['locale' => 'de']),
@@ -117,7 +117,7 @@ class DimensionCollectionTest extends TestCase
     {
         $dimensionCollection = $this->createDimensionCollection([
             'locale' => 'de',
-            'workflowStage' => 'draft',
+            'stage' => 'draft',
         ], [
             $unlocalizedDimension = $this->createDimension('123-456'),
             $this->createDimension('456-789', ['locale' => 'de']),
@@ -125,7 +125,7 @@ class DimensionCollectionTest extends TestCase
 
         $this->assertSame([
             'locale' => null,
-            'workflowStage' => 'draft',
+            'stage' => 'draft',
         ], $dimensionCollection->getUnlocalizedAttributes());
     }
 
@@ -133,7 +133,7 @@ class DimensionCollectionTest extends TestCase
     {
         $dimensionCollection = $this->createDimensionCollection([
             'locale' => 'de',
-            'workflowStage' => 'draft',
+            'stage' => 'draft',
         ], [
             $this->createDimension('123-456'),
             $localizedDimdension = $this->createDimension('456-789', ['locale' => 'de']),
@@ -141,7 +141,7 @@ class DimensionCollectionTest extends TestCase
 
         $this->assertSame([
             'locale' => 'de',
-            'workflowStage' => 'draft',
+            'stage' => 'draft',
         ], $dimensionCollection->getLocalizedAttributes());
     }
 
@@ -149,7 +149,7 @@ class DimensionCollectionTest extends TestCase
     {
         $dimensionCollection = $this->createDimensionCollection([
             'locale' => 'de',
-            'workflowStage' => 'draft',
+            'stage' => 'draft',
         ], [
             $this->createDimension('123-456'),
             $this->createDimension('456-789', ['locale' => 'de']),

--- a/Tests/Unit/Content/Domain/Model/DimensionTest.php
+++ b/Tests/Unit/Content/Domain/Model/DimensionTest.php
@@ -56,19 +56,19 @@ class DimensionTest extends TestCase
     public function testGetPublishedSetNothing(): void
     {
         $dimension = $this->createDimension();
-        $this->assertSame('draft', $dimension->getWorkflowStage());
+        $this->assertSame('draft', $dimension->getStage());
     }
 
     public function testGetPublishedSetLive(): void
     {
-        $dimension = $this->createDimension(null, ['workflowStage' => 'live']);
-        $this->assertSame('live', $dimension->getWorkflowStage());
+        $dimension = $this->createDimension(null, ['stage' => 'live']);
+        $this->assertSame('live', $dimension->getStage());
     }
 
     public function testGetPublishedSetDraft(): void
     {
-        $dimension = $this->createDimension(null, ['workflowStage' => 'draft']);
-        $this->assertSame('draft', $dimension->getWorkflowStage());
+        $dimension = $this->createDimension(null, ['stage' => 'draft']);
+        $this->assertSame('draft', $dimension->getStage());
     }
 
     public function testGetAttributesDefaults(): void
@@ -76,7 +76,7 @@ class DimensionTest extends TestCase
         $dimension = $this->createDimension();
         $this->assertSame([
             'locale' => null,
-            'workflowStage' => 'draft',
+            'stage' => 'draft',
         ], $dimension->getAttributes());
     }
 
@@ -85,25 +85,25 @@ class DimensionTest extends TestCase
         $dimension = $this->createDimension(null, ['locale' => 'de']);
         $this->assertSame([
             'locale' => 'de',
-            'workflowStage' => 'draft',
+            'stage' => 'draft',
         ], $dimension->getAttributes());
     }
 
-    public function testGetAttributesWithWorkflowStage(): void
+    public function testGetAttributesWithStage(): void
     {
-        $dimension = $this->createDimension(null, ['workflowStage' => 'live']);
+        $dimension = $this->createDimension(null, ['stage' => 'live']);
         $this->assertSame([
             'locale' => null,
-            'workflowStage' => 'live',
+            'stage' => 'live',
         ], $dimension->getAttributes());
     }
 
-    public function testGetAttributesWithWorkflowStageAndLocale(): void
+    public function testGetAttributesWithStageAndLocale(): void
     {
-        $dimension = $this->createDimension(null, ['locale' => 'de', 'workflowStage' => 'live']);
+        $dimension = $this->createDimension(null, ['locale' => 'de', 'stage' => 'live']);
         $this->assertSame([
             'locale' => 'de',
-            'workflowStage' => 'live',
+            'stage' => 'live',
         ], $dimension->getAttributes());
     }
 }

--- a/Tests/Unit/Content/Infrastructure/Sulu/Route/ContentRouteDefaultsProviderTest.php
+++ b/Tests/Unit/Content/Infrastructure/Sulu/Route/ContentRouteDefaultsProviderTest.php
@@ -98,7 +98,7 @@ class ContentRouteDefaultsProviderTest extends TestCase
             Argument::that(
                 function (LoadContentViewMessage $message) use ($content) {
                     return $content->reveal() === $message->getContent()
-                        && ['locale' => 'en', 'workflowStage' => 'draft'] === $message->getDimensionAttributes();
+                        && ['locale' => 'en', 'stage' => 'draft'] === $message->getDimensionAttributes();
                 }
             )
         )->will(
@@ -171,7 +171,7 @@ class ContentRouteDefaultsProviderTest extends TestCase
             Argument::that(
                 function (LoadContentViewMessage $message) use ($content) {
                     return $content->reveal() === $message->getContent()
-                        && ['locale' => 'en', 'workflowStage' => 'draft'] === $message->getDimensionAttributes();
+                        && ['locale' => 'en', 'stage' => 'draft'] === $message->getDimensionAttributes();
                 }
             )
         )->willThrow(new HandlerFailedException(new Envelope(new \stdClass()), [new \Exception()]));
@@ -211,7 +211,7 @@ class ContentRouteDefaultsProviderTest extends TestCase
             Argument::that(
                 function (LoadContentViewMessage $message) use ($content) {
                     return $content->reveal() === $message->getContent()
-                        && ['locale' => 'en', 'workflowStage' => 'draft'] === $message->getDimensionAttributes();
+                        && ['locale' => 'en', 'stage' => 'draft'] === $message->getDimensionAttributes();
                 }
             )
         )->will(
@@ -267,7 +267,7 @@ class ContentRouteDefaultsProviderTest extends TestCase
             Argument::that(
                 function (LoadContentViewMessage $message) use ($content) {
                     return $content->reveal() === $message->getContent()
-                        && ['locale' => 'en', 'workflowStage' => 'draft'] === $message->getDimensionAttributes();
+                        && ['locale' => 'en', 'stage' => 'draft'] === $message->getDimensionAttributes();
                 }
             )
         )->willThrow(new HandlerFailedException(new Envelope(new \stdClass()), [new \Exception()]));
@@ -313,7 +313,7 @@ class ContentRouteDefaultsProviderTest extends TestCase
             Argument::that(
                 function (LoadContentViewMessage $message) use ($content) {
                     return $content->reveal() === $message->getContent()
-                        && ['locale' => 'en', 'workflowStage' => 'draft'] === $message->getDimensionAttributes();
+                        && ['locale' => 'en', 'stage' => 'draft'] === $message->getDimensionAttributes();
                 }
             )
         )->will(

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -22,7 +22,7 @@ parameters:
     doctrine:
         objectManagerLoader: Tests/phpstan/object-manager.php
     autoload_files:
-        - vendor/bin/.phpunit/phpunit-8/vendor/autoload.php
+        - vendor/bin/.phpunit/phpunit-8-0/vendor/autoload.php
         - vendor/autoload.php
     ignoreErrors:
         # See https://github.com/phpstan/phpstan/issues/2600


### PR DESCRIPTION
The Dimension workflowStage should be renamed to stage. The dimensions itself has nothing todo with the workflow. In future a ContentDimension will have its own workflow and we will implement a basic publishing workflow into the ContentBundle but its state/place will be saved on the ContentDimension entity.