### PR TITLE
Add ContentViewResolver service for resolving ContentView instances

### DIFF
--- a/EventSubscriber/ContentViewSerializationSubscriber.php
+++ b/EventSubscriber/ContentViewSerializationSubscriber.php
@@ -19,9 +19,6 @@ use JMS\Serializer\EventDispatcher\ObjectEvent;
 use JMS\Serializer\Metadata\StaticPropertyMetadata;
 use JMS\Serializer\Visitor\SerializationVisitorInterface;
 use Sulu\Bundle\ContentBundle\Model\Content\ContentViewInterface;
-use Sulu\Component\Content\Compat\StructureInterface;
-use Sulu\Component\Content\Compat\StructureManagerInterface;
-use Sulu\Component\Content\ContentTypeManagerInterface;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
 
 class ContentViewSerializationSubscriber implements EventSubscriberInterface
@@ -41,36 +38,13 @@ class ContentViewSerializationSubscriber implements EventSubscriberInterface
      */
     private $factory;
 
-    /**
-     * @var StructureManagerInterface
-     */
-    private $structureManager;
-
-    /**
-     * @var ContentTypeManagerInterface
-     */
-    private $contentTypeManager;
-
     public function __construct(
-        StructureMetadataFactoryInterface $factory,
-        StructureManagerInterface $structureManager,
-        ContentTypeManagerInterface $contentTypeManager
+        StructureMetadataFactoryInterface $structureMetadataFactory
     ) {
-        $this->factory = $factory;
-        $this->structureManager = $structureManager;
-        $this->contentTypeManager = $contentTypeManager;
+        $this->factory = $structureMetadataFactory;
     }
 
     public function onPostSerialize(ObjectEvent $event): void
-    {
-        if ($event->getContext()->hasAttribute('array_serializer')) {
-            $this->onPostSerializeArray($event);
-        } else {
-            $this->onPostSerializeJson($event);
-        }
-    }
-
-    public function onPostSerializeJson(ObjectEvent $event): void
     {
         $object = $event->getObject();
         if (!$object instanceof ContentViewInterface) {
@@ -97,78 +71,5 @@ class ContentViewSerializationSubscriber implements EventSubscriberInterface
                 $value
             );
         }
-    }
-
-    public function onPostSerializeArray(ObjectEvent $event): void
-    {
-        $object = $event->getObject();
-        if (!$object instanceof ContentViewInterface) {
-            return;
-        }
-
-        $structure = $this->getStructure($object);
-        if (!$structure) {
-            return;
-        }
-
-        $data = $object->getData() ?? [];
-
-        /** @var SerializationVisitorInterface $visitor */
-        $visitor = $event->getVisitor();
-
-        $content = $this->resolveContent($structure, $data);
-        $visitor->visitProperty(
-            new StaticPropertyMetadata('', 'content', $content),
-            $content
-        );
-
-        $view = $this->resolveView($structure, $data);
-        $visitor->visitProperty(
-            new StaticPropertyMetadata('', 'view', $view),
-            $view
-        );
-    }
-
-    private function getStructure(ContentViewInterface $contentView): ?StructureInterface
-    {
-        $contentType = $contentView->getType();
-        if (!$contentType) {
-            return null;
-        }
-
-        $structure = $this->structureManager->getStructure($contentType, $contentView->getResourceKey());
-        $structure->setLanguageCode($contentView->getLocale());
-
-        return $structure;
-    }
-
-    private function resolveView(StructureInterface $structure, array $data): array
-    {
-        $view = [];
-        foreach ($structure->getProperties(true) as $child) {
-            if (\array_key_exists($child->getName(), $data)) {
-                $child->setValue($data[$child->getName()]);
-            }
-
-            $contentType = $this->contentTypeManager->get($child->getContentTypeName());
-            $view[$child->getName()] = $contentType->getViewData($child);
-        }
-
-        return $view;
-    }
-
-    private function resolveContent(StructureInterface $structure, array $data): array
-    {
-        $content = [];
-        foreach ($structure->getProperties(true) as $child) {
-            if (\array_key_exists($child->getName(), $data)) {
-                $child->setValue($data[$child->getName()]);
-            }
-
-            $contentType = $this->contentTypeManager->get($child->getContentTypeName());
-            $content[$child->getName()] = $contentType->getContentData($child);
-        }
-
-        return $content;
     }
 }

--- a/Resolver/ContentViewResolver.php
+++ b/Resolver/ContentViewResolver.php
@@ -49,6 +49,7 @@ class ContentViewResolver implements ContentViewResolverInterface
 
         return [
             'id' => $contentView->getResourceId(),
+            'template' => $contentView->getType(),
             'content' => $this->resolveContent($structure, $data),
             'view' => $this->resolveView($structure, $data),
         ];

--- a/Resolver/ContentViewResolver.php
+++ b/Resolver/ContentViewResolver.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Resolver;
+
+use Sulu\Bundle\ContentBundle\Model\Content\ContentViewInterface;
+use Sulu\Component\Content\Compat\StructureInterface;
+use Sulu\Component\Content\Compat\StructureManagerInterface;
+use Sulu\Component\Content\ContentTypeManagerInterface;
+
+class ContentViewResolver implements ContentViewResolverInterface
+{
+    /**
+     * @var StructureManagerInterface
+     */
+    private $structureManager;
+
+    /**
+     * @var ContentTypeManagerInterface
+     */
+    private $contentTypeManager;
+
+    public function __construct(
+        StructureManagerInterface $structureManager,
+        ContentTypeManagerInterface $contentTypeManager
+    ) {
+        $this->structureManager = $structureManager;
+        $this->contentTypeManager = $contentTypeManager;
+    }
+
+    public function resolve(ContentViewInterface $contentView): array
+    {
+        $structure = $this->getStructure($contentView);
+        $data = $contentView->getData() ?? [];
+
+        if (!$structure) {
+            return [];
+        }
+
+        return [
+            'id' => $contentView->getResourceId(),
+            'content' => $this->resolveContent($structure, $data),
+            'view' => $this->resolveView($structure, $data),
+        ];
+    }
+
+    private function getStructure(ContentViewInterface $contentView): ?StructureInterface
+    {
+        $contentType = $contentView->getType();
+        if (!$contentType) {
+            return null;
+        }
+
+        $structure = $this->structureManager->getStructure($contentType, $contentView->getResourceKey());
+        $structure->setLanguageCode($contentView->getLocale());
+
+        return $structure;
+    }
+
+    private function resolveView(StructureInterface $structure, array $data): array
+    {
+        $view = [];
+        foreach ($structure->getProperties(true) as $child) {
+            if (\array_key_exists($child->getName(), $data)) {
+                $child->setValue($data[$child->getName()]);
+            }
+
+            $contentType = $this->contentTypeManager->get($child->getContentTypeName());
+            $view[$child->getName()] = $contentType->getViewData($child);
+        }
+
+        return $view;
+    }
+
+    private function resolveContent(StructureInterface $structure, array $data): array
+    {
+        $content = [];
+        foreach ($structure->getProperties(true) as $child) {
+            if (\array_key_exists($child->getName(), $data)) {
+                $child->setValue($data[$child->getName()]);
+            }
+
+            $contentType = $this->contentTypeManager->get($child->getContentTypeName());
+            $content[$child->getName()] = $contentType->getContentData($child);
+        }
+
+        return $content;
+    }
+}

--- a/Resolver/ContentViewResolverInterface.php
+++ b/Resolver/ContentViewResolverInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Resolver;
+
+use Sulu\Bundle\ContentBundle\Model\Content\ContentViewInterface;
+
+interface ContentViewResolverInterface
+{
+    public function resolve(ContentViewInterface $contentView): array;
+}

--- a/Resources/config/services/content.xml
+++ b/Resources/config/services/content.xml
@@ -78,6 +78,7 @@
             <argument type="service" id="sulu.content.type_manager"/>
         </service>
         <service id="Sulu\Bundle\ContentBundle\Resolver\ContentViewResolverInterface"
-                 alias="Sulu\Bundle\ContentBundle\Resolver\ContentViewResolver"/>
+                 alias="Sulu\Bundle\ContentBundle\Resolver\ContentViewResolver"
+                 public="true"/>
     </services>
 </container>

--- a/Resources/config/services/content.xml
+++ b/Resources/config/services/content.xml
@@ -71,5 +71,13 @@
 
             <tag name="jms_serializer.event_subscriber"/>
         </service>
+
+        <!-- resolver -->
+        <service id="Sulu\Bundle\ContentBundle\Resolver\ContentViewResolver">
+            <argument type="service" id="sulu.content.structure_manager"/>
+            <argument type="service" id="sulu.content.type_manager"/>
+        </service>
+        <service id="Sulu\Bundle\ContentBundle\Resolver\ContentViewResolverInterface"
+                 alias="Sulu\Bundle\ContentBundle\Resolver\ContentViewResolver"/>
     </services>
 </container>


### PR DESCRIPTION
This PR introduces a `ContentViewResolver` service that resolves the data of a `ContentView` instance with the respective content types. 

This functionality was implemented in a `SerializationSubscriber` before. That approach does not work anymore since the `jms/serializer` dependency was updated.