### PR TITLE
Disable TypeToolbar when having no permission

### DIFF
--- a/Content/Infrastructure/Sulu/Admin/ContentViewBuilder.php
+++ b/Content/Infrastructure/Sulu/Admin/ContentViewBuilder.php
@@ -74,7 +74,7 @@ class ContentViewBuilder implements ContentViewBuilderInterface
             new ToolbarAction(
                 'sulu_admin.type',
                 [
-                    'display_condition' => '(!_permissions || _permissions.edit)',
+                    'disable_condition' => '(_permissions && !_permissions.edit)',
                 ]
             ),
             new ToolbarAction(


### PR DESCRIPTION
This will disable the TypeToolbar when having no permisisons for it.