### PR TITLE
Declare entity-independent methods on marker interfaces as static

### DIFF
--- a/Content/Application/ContentWorkflow/ContentWorkflow.php
+++ b/Content/Application/ContentWorkflow/ContentWorkflow.php
@@ -113,7 +113,7 @@ class ContentWorkflow implements ContentWorkflowInterface
 
         $workflow = $this->workflowRegistry->get(
             $localizedDimensionContent,
-            $localizedDimensionContent->getWorkflowName()
+            $localizedDimensionContent::getWorkflowName()
         );
 
         try {

--- a/Content/Application/DimensionContentCollectionFactory/DataMapper/RoutableDataMapper.php
+++ b/Content/Application/DimensionContentCollectionFactory/DataMapper/RoutableDataMapper.php
@@ -71,7 +71,7 @@ class RoutableDataMapper implements DataMapperInterface
             throw new \RuntimeException('LocalizedObject needs to extend the TemplateInterface');
         }
 
-        $type = $localizedObject->getTemplateType();
+        $type = $localizedObject::getTemplateType();
 
         /** @var string|null $template */
         $template = $data['template'] ?? null;
@@ -134,7 +134,7 @@ class RoutableDataMapper implements DataMapperInterface
         }
 
         $this->routeManager->createOrUpdateByAttributes(
-            $localizedObject->getContentClass(),
+            $localizedObject::getContentClass(),
             (string) $localizedObject->getContentId(),
             $locale,
             $routePath

--- a/Content/Application/DimensionContentCollectionFactory/DataMapper/TemplateDataMapper.php
+++ b/Content/Application/DimensionContentCollectionFactory/DataMapper/TemplateDataMapper.php
@@ -46,7 +46,7 @@ class TemplateDataMapper implements DataMapperInterface
             return;
         }
 
-        $type = $unlocalizedObject->getTemplateType();
+        $type = $unlocalizedObject::getTemplateType();
 
         /** @var string|null $template */
         $template = $data['template'] ?? null;

--- a/Content/Domain/Model/RoutableInterface.php
+++ b/Content/Domain/Model/RoutableInterface.php
@@ -18,7 +18,7 @@ namespace Sulu\Bundle\ContentBundle\Content\Domain\Model;
  */
 interface RoutableInterface
 {
-    public function getContentClass(): string;
+    public static function getContentClass(): string;
 
     /**
      * @return mixed

--- a/Content/Domain/Model/TemplateInterface.php
+++ b/Content/Domain/Model/TemplateInterface.php
@@ -15,6 +15,8 @@ namespace Sulu\Bundle\ContentBundle\Content\Domain\Model;
 
 interface TemplateInterface
 {
+    public static function getTemplateType(): string;
+
     public function getTemplateKey(): ?string;
 
     public function setTemplateKey(string $templateKey): void;
@@ -28,6 +30,4 @@ interface TemplateInterface
      * @param mixed[] $templateData
      */
     public function setTemplateData(array $templateData): void;
-
-    public function getTemplateType(): string;
 }

--- a/Content/Domain/Model/WorkflowInterface.php
+++ b/Content/Domain/Model/WorkflowInterface.php
@@ -45,6 +45,8 @@ interface WorkflowInterface
 
     const WORKFLOW_DEFAULT_NAME = 'content_workflow';
 
+    public static function getWorkflowName(): string;
+
     public function getWorkflowPlace(): string;
 
     public function setWorkflowPlace(string $workflowPlace): void;
@@ -52,6 +54,4 @@ interface WorkflowInterface
     public function getWorkflowPublished(): ?\DateTimeImmutable;
 
     public function setWorkflowPublished(?\DateTimeImmutable $workflowPublished): void;
-
-    public function getWorkflowName(): string;
 }

--- a/Content/Domain/Model/WorkflowTrait.php
+++ b/Content/Domain/Model/WorkflowTrait.php
@@ -53,7 +53,7 @@ trait WorkflowTrait
         $this->workflowPublished = $workflowPublished;
     }
 
-    public function getWorkflowName(): string
+    public static function getWorkflowName(): string
     {
         return WorkflowInterface::WORKFLOW_DEFAULT_NAME;
     }

--- a/Content/Infrastructure/Sulu/Route/ContentRouteDefaultsProvider.php
+++ b/Content/Infrastructure/Sulu/Route/ContentRouteDefaultsProvider.php
@@ -71,7 +71,7 @@ class ContentRouteDefaultsProvider implements RouteDefaultsProviderInterface
         }
 
         $metadata = $this->structureMetadataFactory->getStructureMetadata(
-            $entity->getTemplateType(),
+            $entity::getTemplateType(),
             $entity->getTemplateKey()
         );
         if (!$metadata) {

--- a/Tests/Application/ExampleTestBundle/Entity/ExampleContentProjection.php
+++ b/Tests/Application/ExampleTestBundle/Entity/ExampleContentProjection.php
@@ -72,7 +72,7 @@ class ExampleContentProjection extends AbstractContentProjection implements SeoI
         $this->title = $title;
     }
 
-    public function getTemplateType(): string
+    public static function getTemplateType(): string
     {
         return Example::TEMPLATE_TYPE;
     }

--- a/Tests/Application/ExampleTestBundle/Entity/ExampleDimensionContent.php
+++ b/Tests/Application/ExampleTestBundle/Entity/ExampleDimensionContent.php
@@ -102,12 +102,12 @@ class ExampleDimensionContent extends AbstractDimensionContent implements Excerp
         return $contentProjection;
     }
 
-    public function getTemplateType(): string
+    public static function getTemplateType(): string
     {
         return Example::TEMPLATE_TYPE;
     }
 
-    public function getContentClass(): string
+    public static function getContentClass(): string
     {
         return Example::class;
     }

--- a/Tests/Unit/Content/Application/ContentProjectionNormalizer/ContentProjectionNormalizerTest.php
+++ b/Tests/Unit/Content/Application/ContentProjectionNormalizer/ContentProjectionNormalizerTest.php
@@ -77,7 +77,7 @@ class ContentProjectionNormalizerTest extends TestCase
                 return 5;
             }
 
-            public function getTemplateType(): string
+            public static function getTemplateType(): string
             {
                 return 'example';
             }

--- a/Tests/Unit/Content/Domain/Model/ContentRichEntityTest.php
+++ b/Tests/Unit/Content/Domain/Model/ContentRichEntityTest.php
@@ -66,7 +66,7 @@ class ContentRichEntityTest extends TestCase
                 };
             }
 
-            public function getTemplateType(): string
+            public static function getTemplateType(): string
             {
                 return 'example';
             }

--- a/Tests/Unit/Content/Domain/Model/RoutableTraitTest.php
+++ b/Tests/Unit/Content/Domain/Model/RoutableTraitTest.php
@@ -35,9 +35,9 @@ class RoutableTraitTest extends TestCase
                 $this->dimension = $dimension;
             }
 
-            public function getContentClass(): string
+            public static function getContentClass(): string
             {
-                return \get_class($this);
+                return self::class;
             }
 
             public function getContentId()

--- a/Tests/Unit/Content/Domain/Model/TemplateTraitTest.php
+++ b/Tests/Unit/Content/Domain/Model/TemplateTraitTest.php
@@ -24,7 +24,7 @@ class TemplateTraitTest extends TestCase
         return new class() implements TemplateInterface {
             use TemplateTrait;
 
-            public function getTemplateType(): string
+            public static function getTemplateType(): string
             {
                 return 'example';
             }
@@ -50,6 +50,6 @@ class TemplateTraitTest extends TestCase
     public function testGetTemplateType(): void
     {
         $model = $this->getTemplateInstance();
-        $this->assertSame('example', $model->getTemplateType());
+        $this->assertSame('example', $model::getTemplateType());
     }
 }

--- a/Tests/Unit/Content/Domain/Model/WorkflowTraitTest.php
+++ b/Tests/Unit/Content/Domain/Model/WorkflowTraitTest.php
@@ -128,6 +128,6 @@ class WorkflowTraitTest extends TestCase
     public function testGetWorkflowName(): void
     {
         $workflow = $this->getWorkflowInstance();
-        $this->assertSame('content_workflow', $workflow->getWorkflowName());
+        $this->assertSame('content_workflow', $workflow::getWorkflowName());
     }
 }

--- a/Tests/Unit/Content/Infrastructure/Sulu/Preview/ContentObjectProviderTest.php
+++ b/Tests/Unit/Content/Infrastructure/Sulu/Preview/ContentObjectProviderTest.php
@@ -225,7 +225,7 @@ class ContentObjectProviderTest extends TestCase
                 return 1;
             }
 
-            public function getTemplateType(): string
+            public static function getTemplateType(): string
             {
                 return 'example';
             }
@@ -269,7 +269,7 @@ class ContentObjectProviderTest extends TestCase
                 return 1;
             }
 
-            public function getTemplateType(): string
+            public static function getTemplateType(): string
             {
                 return 'example';
             }


### PR DESCRIPTION
- [ ] `RoutableInterface:: getContentClass`
- [x] `TemplateInterface:: getTemplateType`
- [ ] `WorkflowInterface:: getWorkflowName`