### PR TITLE
Add constants for keys of ContentWorkflow transition context

### DIFF
--- a/Content/Application/ContentWorkflow/ContentWorkflow.php
+++ b/Content/Application/ContentWorkflow/ContentWorkflow.php
@@ -118,9 +118,9 @@ class ContentWorkflow implements ContentWorkflowInterface
 
         try {
             $workflow->apply($localizedDimensionContent, $transitionName, [
-                'contentRichEntity' => $contentRichEntity,
-                'dimensionContentCollection' => $dimensionContentCollection,
-                'dimensionAttributes' => $dimensionAttributes,
+                ContentWorkflowInterface::CONTENT_RICH_ENTITY_CONTEXT_KEY => $contentRichEntity,
+                ContentWorkflowInterface::DIMENSION_CONTENT_COLLECTION_CONTEXT_KEY => $dimensionContentCollection,
+                ContentWorkflowInterface::DIMENSION_ATTRIBUTES_CONTEXT_KEY => $dimensionAttributes,
             ]);
         } catch (UndefinedTransitionException $e) {
             throw new UnknownContentTransitionException($e->getMessage(), $e->getCode(), $e);

--- a/Content/Application/ContentWorkflow/ContentWorkflowInterface.php
+++ b/Content/Application/ContentWorkflow/ContentWorkflowInterface.php
@@ -18,6 +18,10 @@ use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 
 interface ContentWorkflowInterface
 {
+    const CONTENT_RICH_ENTITY_CONTEXT_KEY = 'contentRichEntity';
+    const DIMENSION_CONTENT_COLLECTION_CONTEXT_KEY = 'dimensionContentCollection';
+    const DIMENSION_ATTRIBUTES_CONTEXT_KEY = 'dimensionAttributes';
+
     /**
      * @param mixed[] $dimensionAttributes
      */

--- a/Content/Application/ContentWorkflow/Subscriber/PublishTransitionSubscriber.php
+++ b/Content/Application/ContentWorkflow/Subscriber/PublishTransitionSubscriber.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Bundle\ContentBundle\Content\Application\ContentWorkflow\Subscriber;
 
 use Sulu\Bundle\ContentBundle\Content\Application\ContentCopier\ContentCopierInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentWorkflow\ContentWorkflowInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentRichEntityInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
@@ -50,9 +51,9 @@ class PublishTransitionSubscriber implements EventSubscriberInterface
 
         $context = $transitionEvent->getContext();
 
-        $dimensionContentCollection = $context['dimensionContentCollection'] ?? null;
-        $dimensionAttributes = $context['dimensionAttributes'] ?? null;
-        $contentRichEntity = $context['contentRichEntity'] ?? null;
+        $dimensionContentCollection = $context[ContentWorkflowInterface::DIMENSION_CONTENT_COLLECTION_CONTEXT_KEY] ?? null;
+        $dimensionAttributes = $context[ContentWorkflowInterface::DIMENSION_ATTRIBUTES_CONTEXT_KEY] ?? null;
+        $contentRichEntity = $context[ContentWorkflowInterface::CONTENT_RICH_ENTITY_CONTEXT_KEY] ?? null;
 
         if (!$dimensionAttributes) {
             throw new \RuntimeException('No "dimensionAttributes" given.');

--- a/Content/Application/ContentWorkflow/Subscriber/RemoveDraftTransitionSubscriber.php
+++ b/Content/Application/ContentWorkflow/Subscriber/RemoveDraftTransitionSubscriber.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Bundle\ContentBundle\Content\Application\ContentWorkflow\Subscriber;
 
 use Sulu\Bundle\ContentBundle\Content\Application\ContentCopier\ContentCopierInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentWorkflow\ContentWorkflowInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentRichEntityInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionInterface;
@@ -41,12 +42,12 @@ class RemoveDraftTransitionSubscriber implements EventSubscriberInterface
 
         $context = $transitionEvent->getContext();
 
-        $dimensionAttributes = $context['dimensionAttributes'] ?? null;
+        $dimensionAttributes = $context[ContentWorkflowInterface::DIMENSION_ATTRIBUTES_CONTEXT_KEY] ?? null;
         if (!$dimensionAttributes) {
             throw new \RuntimeException('Transition context must contain "dimensionAttributes".');
         }
 
-        $contentRichEntity = $context['contentRichEntity'] ?? null;
+        $contentRichEntity = $context[ContentWorkflowInterface::CONTENT_RICH_ENTITY_CONTEXT_KEY] ?? null;
         if (!$contentRichEntity instanceof ContentRichEntityInterface) {
             throw new \RuntimeException('Transition context must contain "contentRichEntity".');
         }

--- a/Content/Application/ContentWorkflow/Subscriber/UnpublishTransitionSubscriber.php
+++ b/Content/Application/ContentWorkflow/Subscriber/UnpublishTransitionSubscriber.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Bundle\ContentBundle\Content\Application\ContentWorkflow\Subscriber;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentWorkflow\ContentWorkflowInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Exception\ContentNotFoundException;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentRichEntityInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
@@ -65,12 +66,12 @@ class UnpublishTransitionSubscriber implements EventSubscriberInterface
 
         $context = $transitionEvent->getContext();
 
-        $dimensionAttributes = $context['dimensionAttributes'] ?? null;
+        $dimensionAttributes = $context[ContentWorkflowInterface::DIMENSION_ATTRIBUTES_CONTEXT_KEY] ?? null;
         if (!$dimensionAttributes) {
             throw new \RuntimeException('Transition context must contain "dimensionAttributes".');
         }
 
-        $contentRichEntity = $context['contentRichEntity'] ?? null;
+        $contentRichEntity = $context[ContentWorkflowInterface::CONTENT_RICH_ENTITY_CONTEXT_KEY] ?? null;
         if (!$contentRichEntity instanceof ContentRichEntityInterface) {
             throw new \RuntimeException('Transition context must contain "contentRichEntity".');
         }

--- a/Content/Infrastructure/Sulu/Sitemap/ContentSitemapProvider.php
+++ b/Content/Infrastructure/Sulu/Sitemap/ContentSitemapProvider.php
@@ -18,6 +18,7 @@ use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentWorkflow\ContentWorkflowInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionInterface;
 use Sulu\Bundle\RouteBundle\Model\RouteInterface;
 use Sulu\Bundle\WebsiteBundle\Sitemap\Sitemap;
@@ -31,7 +32,7 @@ use Sulu\Component\Webspace\PortalInformation;
 class ContentSitemapProvider implements SitemapProviderInterface
 {
     const ROUTE_ALIAS = 'route';
-    const CONTENT_RICH_ENTITY_ALIAS = 'contentRichEntity';
+    const CONTENT_RICH_ENTITY_ALIAS = ContentWorkflowInterface::CONTENT_RICH_ENTITY_CONTEXT_KEY;
     const LOCALIZED_DIMENSION_CONTENT_ALIAS = 'localizedDimensionContent';
     const LOCALIZED_DIMENSION_ALIAS = 'localizedDimension';
 

--- a/Content/Infrastructure/Sulu/Teaser/ContentTeaserProvider.php
+++ b/Content/Infrastructure/Sulu/Teaser/ContentTeaserProvider.php
@@ -15,6 +15,7 @@ namespace Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Teaser;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentManager\ContentManagerInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentWorkflow\ContentWorkflowInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Exception\ContentNotFoundException;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentRichEntityInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
@@ -27,7 +28,7 @@ use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
 
 abstract class ContentTeaserProvider implements TeaserProviderInterface
 {
-    const CONTENT_RICH_ENTITY_ALIAS = 'contentRichEntity';
+    const CONTENT_RICH_ENTITY_ALIAS = ContentWorkflowInterface::CONTENT_RICH_ENTITY_CONTEXT_KEY;
 
     /**
      * @var ContentManagerInterface

--- a/Tests/Unit/Content/Application/ContentWorkflow/Subscriber/PublishTransitionSubscriberTest.php
+++ b/Tests/Unit/Content/Application/ContentWorkflow/Subscriber/PublishTransitionSubscriberTest.php
@@ -16,6 +16,7 @@ namespace Sulu\Bundle\ContentBundle\Tests\Unit\Content\Application\ContentWorkfl
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentCopier\ContentCopierInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentWorkflow\ContentWorkflowInterface;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentWorkflow\Subscriber\PublishTransitionSubscriber;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentRichEntityInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
@@ -72,8 +73,8 @@ class PublishTransitionSubscriberTest extends TestCase
             new Marking()
         );
         $event->setContext([
-            'dimensionAttributes' => $dimensionAttributes,
-            'contentRichEntity' => $contentRichEntity->reveal(),
+            ContentWorkflowInterface::DIMENSION_ATTRIBUTES_CONTEXT_KEY => $dimensionAttributes,
+            ContentWorkflowInterface::CONTENT_RICH_ENTITY_CONTEXT_KEY => $contentRichEntity->reveal(),
         ]);
 
         $contentCopier = $this->prophesize(ContentCopierInterface::class);
@@ -99,8 +100,8 @@ class PublishTransitionSubscriberTest extends TestCase
             new Marking()
         );
         $event->setContext([
-            'dimensionAttributes' => $dimensionAttributes,
-            'dimensionContentCollection' => $dimensionContentCollection->reveal(),
+            ContentWorkflowInterface::DIMENSION_ATTRIBUTES_CONTEXT_KEY => $dimensionAttributes,
+            ContentWorkflowInterface::DIMENSION_CONTENT_COLLECTION_CONTEXT_KEY => $dimensionContentCollection->reveal(),
         ]);
 
         $contentCopier = $this->prophesize(ContentCopierInterface::class);
@@ -126,8 +127,8 @@ class PublishTransitionSubscriberTest extends TestCase
             new Marking()
         );
         $event->setContext([
-            'dimensionContentCollection' => $dimensionContentCollection->reveal(),
-            'contentRichEntity' => $contentRichEntity->reveal(),
+            ContentWorkflowInterface::DIMENSION_CONTENT_COLLECTION_CONTEXT_KEY => $dimensionContentCollection->reveal(),
+            ContentWorkflowInterface::CONTENT_RICH_ENTITY_CONTEXT_KEY => $contentRichEntity->reveal(),
         ]);
 
         $contentCopier = $this->prophesize(ContentCopierInterface::class);
@@ -155,9 +156,9 @@ class PublishTransitionSubscriberTest extends TestCase
             new Marking()
         );
         $event->setContext([
-            'dimensionContentCollection' => $dimensionContentCollection->reveal(),
-            'dimensionAttributes' => $dimensionAttributes,
-            'contentRichEntity' => $contentRichEntity->reveal(),
+            ContentWorkflowInterface::DIMENSION_CONTENT_COLLECTION_CONTEXT_KEY => $dimensionContentCollection->reveal(),
+            ContentWorkflowInterface::DIMENSION_ATTRIBUTES_CONTEXT_KEY => $dimensionAttributes,
+            ContentWorkflowInterface::CONTENT_RICH_ENTITY_CONTEXT_KEY => $contentRichEntity->reveal(),
         ]);
 
         $contentCopier = $this->prophesize(ContentCopierInterface::class);
@@ -194,9 +195,9 @@ class PublishTransitionSubscriberTest extends TestCase
             new Marking()
         );
         $event->setContext([
-            'dimensionContentCollection' => $dimensionContentCollection->reveal(),
-            'dimensionAttributes' => $dimensionAttributes,
-            'contentRichEntity' => $contentRichEntity->reveal(),
+            ContentWorkflowInterface::DIMENSION_CONTENT_COLLECTION_CONTEXT_KEY => $dimensionContentCollection->reveal(),
+            ContentWorkflowInterface::DIMENSION_ATTRIBUTES_CONTEXT_KEY => $dimensionAttributes,
+            ContentWorkflowInterface::CONTENT_RICH_ENTITY_CONTEXT_KEY => $contentRichEntity->reveal(),
         ]);
 
         $contentCopier = $this->prophesize(ContentCopierInterface::class);

--- a/Tests/Unit/Content/Application/ContentWorkflow/Subscriber/RemoveDraftTransitionSubscriberTest.php
+++ b/Tests/Unit/Content/Application/ContentWorkflow/Subscriber/RemoveDraftTransitionSubscriberTest.php
@@ -16,6 +16,7 @@ namespace Sulu\Bundle\ContentBundle\Tests\Unit\Content\Application\ContentWorkfl
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentCopier\ContentCopierInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentWorkflow\ContentWorkflowInterface;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentWorkflow\Subscriber\RemoveDraftTransitionSubscriber;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentRichEntityInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
@@ -70,7 +71,7 @@ class RemoveDraftTransitionSubscriberTest extends TestCase
             new Marking()
         );
         $event->setContext([
-            'contentRichEntity' => $contentRichEntity->reveal(),
+            ContentWorkflowInterface::CONTENT_RICH_ENTITY_CONTEXT_KEY => $contentRichEntity->reveal(),
         ]);
 
         $contentCopier = $this->prophesize(ContentCopierInterface::class);
@@ -94,7 +95,7 @@ class RemoveDraftTransitionSubscriberTest extends TestCase
             new Marking()
         );
         $event->setContext([
-            'dimensionAttributes' => $dimensionAttributes,
+            ContentWorkflowInterface::DIMENSION_ATTRIBUTES_CONTEXT_KEY => $dimensionAttributes,
         ]);
 
         $contentCopier = $this->prophesize(ContentCopierInterface::class);
@@ -116,8 +117,8 @@ class RemoveDraftTransitionSubscriberTest extends TestCase
             new Marking()
         );
         $event->setContext([
-            'dimensionAttributes' => $dimensionAttributes,
-            'contentRichEntity' => $contentRichEntity->reveal(),
+            ContentWorkflowInterface::DIMENSION_ATTRIBUTES_CONTEXT_KEY => $dimensionAttributes,
+            ContentWorkflowInterface::CONTENT_RICH_ENTITY_CONTEXT_KEY => $contentRichEntity->reveal(),
         ]);
 
         $contentCopier = $this->prophesize(ContentCopierInterface::class);

--- a/Tests/Unit/Content/Application/ContentWorkflow/Subscriber/UnpublishTransitionSubscriberTest.php
+++ b/Tests/Unit/Content/Application/ContentWorkflow/Subscriber/UnpublishTransitionSubscriberTest.php
@@ -16,6 +16,7 @@ namespace Sulu\Bundle\ContentBundle\Tests\Unit\Content\Application\ContentWorkfl
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentWorkflow\ContentWorkflowInterface;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentWorkflow\Subscriber\UnpublishTransitionSubscriber;
 use Sulu\Bundle\ContentBundle\Content\Domain\Exception\ContentNotFoundException;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentRichEntityInterface;
@@ -91,7 +92,7 @@ class UnpublishTransitionSubscriberTest extends TestCase
             new Marking()
         );
         $event->setContext([
-            'contentRichEntity' => $contentRichEntity->reveal(),
+            ContentWorkflowInterface::CONTENT_RICH_ENTITY_CONTEXT_KEY => $contentRichEntity->reveal(),
         ]);
 
         $dimensionRepository = $this->prophesize(DimensionRepositoryInterface::class);
@@ -122,7 +123,7 @@ class UnpublishTransitionSubscriberTest extends TestCase
             new Marking()
         );
         $event->setContext([
-            'dimensionAttributes' => $dimensionAttributes,
+            ContentWorkflowInterface::DIMENSION_ATTRIBUTES_CONTEXT_KEY => $dimensionAttributes,
         ]);
 
         $dimensionRepository = $this->prophesize(DimensionRepositoryInterface::class);
@@ -153,8 +154,8 @@ class UnpublishTransitionSubscriberTest extends TestCase
             new Marking()
         );
         $event->setContext([
-            'dimensionAttributes' => $dimensionAttributes,
-            'contentRichEntity' => $contentRichEntity->reveal(),
+            ContentWorkflowInterface::DIMENSION_ATTRIBUTES_CONTEXT_KEY => $dimensionAttributes,
+            ContentWorkflowInterface::CONTENT_RICH_ENTITY_CONTEXT_KEY => $contentRichEntity->reveal(),
         ]);
 
         $dimensionRepository = $this->prophesize(DimensionRepositoryInterface::class);
@@ -192,8 +193,8 @@ class UnpublishTransitionSubscriberTest extends TestCase
             new Marking()
         );
         $event->setContext([
-            'dimensionAttributes' => $dimensionAttributes,
-            'contentRichEntity' => $contentRichEntity->reveal(),
+            ContentWorkflowInterface::DIMENSION_ATTRIBUTES_CONTEXT_KEY => $dimensionAttributes,
+            ContentWorkflowInterface::CONTENT_RICH_ENTITY_CONTEXT_KEY => $contentRichEntity->reveal(),
         ]);
 
         $dimensionRepository = $this->prophesize(DimensionRepositoryInterface::class);
@@ -241,8 +242,8 @@ class UnpublishTransitionSubscriberTest extends TestCase
             new Marking()
         );
         $event->setContext([
-            'dimensionAttributes' => $dimensionAttributes,
-            'contentRichEntity' => $contentRichEntity->reveal(),
+            ContentWorkflowInterface::DIMENSION_ATTRIBUTES_CONTEXT_KEY => $dimensionAttributes,
+            ContentWorkflowInterface::CONTENT_RICH_ENTITY_CONTEXT_KEY => $contentRichEntity->reveal(),
         ]);
 
         $dimensionRepository = $this->prophesize(DimensionRepositoryInterface::class);


### PR DESCRIPTION
I think it would feel better to use a provided constant instead of a string when accessing the context in a project 🙂 