### PR TITLE
Rename AssertResponseContentTrait to AssertSnapshotTrait

### DIFF
--- a/Tests/Functional/BaseTestCase.php
+++ b/Tests/Functional/BaseTestCase.php
@@ -15,12 +15,12 @@ namespace Sulu\Bundle\ContentBundle\Tests\Functional;
 
 use Sulu\Bundle\CategoryBundle\Entity\CategoryRepositoryInterface;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentManager\ContentManagerInterface;
-use Sulu\Bundle\ContentBundle\Tests\Traits\AssertResponseContentTrait;
+use Sulu\Bundle\ContentBundle\Tests\Traits\AssertSnapshotTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
 abstract class BaseTestCase extends SuluTestCase
 {
-    use AssertResponseContentTrait;
+    use AssertSnapshotTrait;
 
     protected static function getContentManager(): ContentManagerInterface
     {

--- a/Tests/Functional/Content/Infrastructure/Sulu/Sitemap/ContentSitemapProviderTest.php
+++ b/Tests/Functional/Content/Infrastructure/Sulu/Sitemap/ContentSitemapProviderTest.php
@@ -78,7 +78,7 @@ class ContentSitemapProviderTest extends BaseTestCase
 
         $sitemapEntries = $this->mapSitemapEntries($sitemapEntries);
 
-        $this->assertContent('sitemap.json', json_encode($sitemapEntries) ?: '');
+        $this->assertArraySnapshot('sitemap.json', $sitemapEntries);
     }
 
     public function testCreateSitemap(): void
@@ -121,10 +121,5 @@ class ContentSitemapProviderTest extends BaseTestCase
                 }, $sitemapUrl->getAlternateLinks()),
             ];
         }, $sitemapEntries);
-    }
-
-    protected function getResponseContentFolder(): string
-    {
-        return 'snapshots';
     }
 }

--- a/Tests/Functional/Content/Infrastructure/Sulu/SmartContent/ContentDataProviderTest.php
+++ b/Tests/Functional/Content/Infrastructure/Sulu/SmartContent/ContentDataProviderTest.php
@@ -300,7 +300,7 @@ class ContentDataProviderTest extends BaseTestCase
 
         $dataItems = $this->mapDataProviderResult($dataProviderResult);
 
-        $this->assertContent('data_items.json', json_encode($dataItems) ?: '');
+        $this->assertArraySnapshot('data_items.json', $dataItems);
     }
 
     public function testResolveResourceItemsSnapshot(): void
@@ -328,7 +328,7 @@ class ContentDataProviderTest extends BaseTestCase
 
         $resourceItems = $this->mapDataProviderResult($dataProviderResult);
 
-        $this->assertContent('resource_items.json', json_encode($resourceItems) ?: '');
+        $this->assertArraySnapshot('resource_items.json', $resourceItems);
     }
 
     /**
@@ -532,10 +532,5 @@ class ContentDataProviderTest extends BaseTestCase
                 'url' => $item['url'],
             ];
         }, $dataProviderResult->getItems());
-    }
-
-    protected function getResponseContentFolder(): string
-    {
-        return 'snapshots';
     }
 }

--- a/Tests/Functional/Content/Infrastructure/Sulu/Teaser/ContentTeaserProviderTest.php
+++ b/Tests/Functional/Content/Infrastructure/Sulu/Teaser/ContentTeaserProviderTest.php
@@ -96,7 +96,7 @@ class ContentTeaserProviderTest extends BaseTestCase
 
         $teasers = $this->mapTeasers($teasers);
 
-        $this->assertContent('teasers_de.json', json_encode($teasers) ?: '');
+        $this->assertArraySnapshot('teasers_de.json', $teasers);
     }
 
     public function testFindEN(): void
@@ -105,7 +105,7 @@ class ContentTeaserProviderTest extends BaseTestCase
 
         $teasers = $this->mapTeasers($teasers);
 
-        $this->assertContent('teasers_en.json', json_encode($teasers) ?: '');
+        $this->assertArraySnapshot('teasers_en.json', $teasers);
     }
 
     /**
@@ -128,10 +128,5 @@ class ContentTeaserProviderTest extends BaseTestCase
                 'attributes' => $teaser->getAttributes(),
             ];
         }, $teasers);
-    }
-
-    protected function getResponseContentFolder(): string
-    {
-        return 'snapshots';
     }
 }

--- a/Tests/Functional/Integration/ExampleControllerTest.php
+++ b/Tests/Functional/Integration/ExampleControllerTest.php
@@ -64,7 +64,7 @@ class ExampleControllerTest extends BaseTestCase
         $content = json_decode((string) $response->getContent(), true);
         $id = $content['id'] ?? null;
 
-        $this->assertResponseContent('example_post_publish.json', $response, 201);
+        $this->assertResponseSnapshot('example_post_publish.json', $response, 201);
         $this->assertNotSame('2020-05-08T00:00:00+00:00', $content['published']);
 
         self::ensureKernelShutdown();
@@ -90,7 +90,7 @@ class ExampleControllerTest extends BaseTestCase
 
         $response = $this->client->getResponse();
 
-        $this->assertResponseContent('example_post_trigger_unpublish.json', $response, 200);
+        $this->assertResponseSnapshot('example_post_trigger_unpublish.json', $response, 200);
 
         self::ensureKernelShutdown();
 
@@ -128,7 +128,7 @@ class ExampleControllerTest extends BaseTestCase
 
         $response = $this->client->getResponse();
 
-        $this->assertResponseContent('example_post.json', $response, 201);
+        $this->assertResponseSnapshot('example_post.json', $response, 201);
 
         $id = json_decode((string) $response->getContent(), true)['id'] ?? null;
 
@@ -142,7 +142,7 @@ class ExampleControllerTest extends BaseTestCase
     {
         $this->client->request('GET', '/admin/api/examples/' . $id . '?locale=en');
         $response = $this->client->getResponse();
-        $this->assertResponseContent('example_get.json', $response, 200);
+        $this->assertResponseSnapshot('example_get.json', $response, 200);
 
         self::ensureKernelShutdown();
 
@@ -182,7 +182,7 @@ class ExampleControllerTest extends BaseTestCase
 
         $response = $this->client->getResponse();
 
-        $this->assertResponseContent('example_put.json', $response, 200);
+        $this->assertResponseSnapshot('example_put.json', $response, 200);
     }
 
     /**
@@ -194,7 +194,7 @@ class ExampleControllerTest extends BaseTestCase
         $this->client->request('GET', '/admin/api/examples?locale=en');
         $response = $this->client->getResponse();
 
-        $this->assertResponseContent('example_cget.json', $response, 200);
+        $this->assertResponseSnapshot('example_cget.json', $response, 200);
     }
 
     /**
@@ -206,5 +206,10 @@ class ExampleControllerTest extends BaseTestCase
         $this->client->request('DELETE', '/admin/api/examples/' . $id . '?locale=en');
         $response = $this->client->getResponse();
         $this->assertHttpStatusCode(204, $response);
+    }
+
+    protected function getSnapshotFolder(): string
+    {
+        return 'responses';
     }
 }

--- a/Tests/Traits/AssertSnapshotTrait.php
+++ b/Tests/Traits/AssertSnapshotTrait.php
@@ -16,15 +16,15 @@ namespace Sulu\Bundle\ContentBundle\Tests\Traits;
 use Coduo\PHPMatcher\PHPUnit\PHPMatcherAssertions;
 use Symfony\Component\HttpFoundation\Response;
 
-trait AssertResponseContentTrait
+trait AssertSnapshotTrait
 {
     use PHPMatcherAssertions;
 
     /**
      * @param object $actualResponse
      */
-    protected function assertResponseContent(
-        string $patternFilename,
+    protected function assertResponseSnapshot(
+        string $snapshotPatternFilename,
         $actualResponse,
         int $statusCode = 200,
         string $message = ''
@@ -34,19 +34,33 @@ trait AssertResponseContentTrait
         $this->assertHttpStatusCode($statusCode, $actualResponse);
         $this->assertIsString($responseContent);
 
-        $this->assertContent($patternFilename, $responseContent, $message);
+        $this->assertSnapshot($snapshotPatternFilename, $responseContent, $message);
     }
 
-    protected function assertContent(
-        string $patternFilename,
+    /**
+     * @param mixed[] $array
+     */
+    protected function assertArraySnapshot(
+        string $snapshotPatternFilename,
+        array $array,
+        string $message = ''
+    ): void {
+        $arrayContent = json_encode($array);
+        $this->assertIsString($arrayContent);
+
+        $this->assertSnapshot($snapshotPatternFilename, $arrayContent, $message);
+    }
+
+    protected function assertSnapshot(
+        string $snapshotPatternFilename,
         string $content,
         string $message = ''
     ): void {
-        $responsesFolder = $this->getCalledClassFolder() . \DIRECTORY_SEPARATOR . $this->getResponseContentFolder();
-        $responsePattern = file_get_contents($responsesFolder . \DIRECTORY_SEPARATOR . $patternFilename);
-        $this->assertIsString($responsePattern);
+        $snapshotFolder = $this->getCalledClassFolder() . \DIRECTORY_SEPARATOR . $this->getSnapshotFolder();
+        $snapshotPattern = file_get_contents($snapshotFolder . \DIRECTORY_SEPARATOR . $snapshotPatternFilename);
+        $this->assertIsString($snapshotPattern);
 
-        $this->assertMatchesPattern(trim($responsePattern), trim($content), $message);
+        $this->assertMatchesPattern(trim($snapshotPattern), trim($content), $message);
     }
 
     private function getCalledClassFolder(): string
@@ -59,8 +73,8 @@ trait AssertResponseContentTrait
         return \dirname($fileName);
     }
 
-    protected function getResponseContentFolder(): string
+    protected function getSnapshotFolder(): string
     {
-        return 'responses';
+        return 'snapshots';
     }
 }


### PR DESCRIPTION
We are using the trait for checking arrays in a few classes. Therefore I think this name would better reflect the usage of the trait 🙂 