### PR TITLE
Add class-string typehints and use consistent naming for contentRichEntityClass arguments

### DIFF
--- a/Content/Infrastructure/Sulu/Admin/ContentViewBuilderFactory.php
+++ b/Content/Infrastructure/Sulu/Admin/ContentViewBuilderFactory.php
@@ -20,6 +20,8 @@ use Sulu\Bundle\AdminBundle\Admin\View\PreviewFormViewBuilderInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentRichEntityInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ExcerptInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\SeoInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\TemplateInterface;
@@ -111,9 +113,7 @@ class ContentViewBuilderFactory implements ContentViewBuilderFactoryInterface
         ?string $securityContext = null,
         ?array $toolbarActions = null
     ): array {
-        $classMetadata = $this->entityManager->getClassMetadata($entityClass);
-        $associationMapping = $classMetadata->getAssociationMapping('dimensionContents');
-        $dimensionContentClass = $associationMapping['targetEntity'];
+        $dimensionContentClass = $this->getDimensionContentClass($entityClass);
 
         /** @var callable $callable */
         $callable = [$entityClass, 'getResourceKey'];
@@ -278,5 +278,18 @@ class ContentViewBuilderFactory implements ContentViewBuilderFactoryInterface
         }
 
         return $this->securityChecker->hasPermission($securityContext, $permissionType);
+    }
+
+    /**
+     * @param class-string<ContentRichEntityInterface> $contentRichEntityClass
+     *
+     * @return class-string<DimensionContentInterface>
+     */
+    private function getDimensionContentClass(string $contentRichEntityClass): string
+    {
+        $classMetadata = $this->entityManager->getClassMetadata($contentRichEntityClass);
+        $associationMapping = $classMetadata->getAssociationMapping('dimensionContents');
+
+        return $associationMapping['targetEntity'];
     }
 }

--- a/Content/Infrastructure/Sulu/Admin/ContentViewBuilderFactory.php
+++ b/Content/Infrastructure/Sulu/Admin/ContentViewBuilderFactory.php
@@ -115,14 +115,7 @@ class ContentViewBuilderFactory implements ContentViewBuilderFactoryInterface
     ): array {
         $dimensionContentClass = $this->getDimensionContentClass($contentRichEntityClass);
 
-        /** @var callable $callable */
-        $callable = [$contentRichEntityClass, 'getResourceKey'];
-        $resourceKey = \call_user_func($callable);
-
-        /** @var callable $callable */
-        $callable = [$dimensionContentClass, 'getTemplateType'];
-        $templateFormKey = \call_user_func($callable);
-
+        $resourceKey = $contentRichEntityClass::getResourceKey();
         $previewEnabled = $this->objectProviderRegistry->hasPreviewObjectProvider($resourceKey);
 
         $toolbarActions = $toolbarActions ?: $this->getDefaultToolbarActions();
@@ -158,7 +151,7 @@ class ContentViewBuilderFactory implements ContentViewBuilderFactoryInterface
                         $addParentView,
                         false,
                         $resourceKey,
-                        $templateFormKey,
+                        $dimensionContentClass::getTemplateType(),
                         $addToolbarActions
                     );
 
@@ -175,7 +168,7 @@ class ContentViewBuilderFactory implements ContentViewBuilderFactoryInterface
                     $editParentView,
                     $previewEnabled,
                     $resourceKey,
-                    $templateFormKey,
+                    $dimensionContentClass::getTemplateType(),
                     $toolbarActions
                 );
             }

--- a/Content/Infrastructure/Sulu/Admin/ContentViewBuilderFactory.php
+++ b/Content/Infrastructure/Sulu/Admin/ContentViewBuilderFactory.php
@@ -107,16 +107,16 @@ class ContentViewBuilderFactory implements ContentViewBuilderFactoryInterface
     }
 
     public function createViews(
-        string $entityClass,
+        string $contentRichEntityClass,
         string $editParentView,
         ?string $addParentView = null,
         ?string $securityContext = null,
         ?array $toolbarActions = null
     ): array {
-        $dimensionContentClass = $this->getDimensionContentClass($entityClass);
+        $dimensionContentClass = $this->getDimensionContentClass($contentRichEntityClass);
 
         /** @var callable $callable */
-        $callable = [$entityClass, 'getResourceKey'];
+        $callable = [$contentRichEntityClass, 'getResourceKey'];
         $resourceKey = \call_user_func($callable);
 
         /** @var callable $callable */

--- a/Content/Infrastructure/Sulu/Admin/ContentViewBuilderFactoryInterface.php
+++ b/Content/Infrastructure/Sulu/Admin/ContentViewBuilderFactoryInterface.php
@@ -25,13 +25,13 @@ interface ContentViewBuilderFactoryInterface
     public function getDefaultToolbarActions(): array;
 
     /**
-     * @param class-string<ContentRichEntityInterface> $entityClass
+     * @param class-string<ContentRichEntityInterface> $contentRichEntityClass
      * @param array<string, ToolbarAction> $toolbarActions
      *
      * @return ViewBuilderInterface[]
      */
     public function createViews(
-        string $entityClass,
+        string $contentRichEntityClass,
         string $editParentView,
         ?string $addParentView = null,
         ?string $securityContext = null,

--- a/Content/Infrastructure/Sulu/Admin/ContentViewBuilderFactoryInterface.php
+++ b/Content/Infrastructure/Sulu/Admin/ContentViewBuilderFactoryInterface.php
@@ -36,5 +36,5 @@ interface ContentViewBuilderFactoryInterface
         ?string $addParentView = null,
         ?string $securityContext = null,
         ?array $toolbarActions = null
-    );
+    ): array;
 }

--- a/Content/Infrastructure/Sulu/Admin/ContentViewBuilderFactoryInterface.php
+++ b/Content/Infrastructure/Sulu/Admin/ContentViewBuilderFactoryInterface.php
@@ -15,6 +15,7 @@ namespace Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Admin;
 
 use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentRichEntityInterface;
 
 interface ContentViewBuilderFactoryInterface
 {
@@ -24,6 +25,7 @@ interface ContentViewBuilderFactoryInterface
     public function getDefaultToolbarActions(): array;
 
     /**
+     * @param class-string<ContentRichEntityInterface> $entityClass
      * @param array<string, ToolbarAction> $toolbarActions
      *
      * @return ViewBuilderInterface[]
@@ -34,5 +36,5 @@ interface ContentViewBuilderFactoryInterface
         ?string $addParentView = null,
         ?string $securityContext = null,
         ?array $toolbarActions = null
-    ): array;
+    );
 }

--- a/Content/Infrastructure/Sulu/Preview/ContentObjectProvider.php
+++ b/Content/Infrastructure/Sulu/Preview/ContentObjectProvider.php
@@ -42,20 +42,23 @@ class ContentObjectProvider implements PreviewObjectProviderInterface
     private $contentDataMapper;
 
     /**
-     * @var string
+     * @var class-string<ContentRichEntityInterface>
      */
-    private $entityClass;
+    private $contentRichEntityClass;
 
+    /**
+     * @param class-string<ContentRichEntityInterface> $contentRichEntityClass
+     */
     public function __construct(
         EntityManagerInterface $entityManager,
         ContentResolverInterface $contentResolver,
         ContentDataMapperInterface $contentDataMapper,
-        string $entityClass
+        string $contentRichEntityClass
     ) {
         $this->entityManager = $entityManager;
         $this->contentResolver = $contentResolver;
         $this->contentDataMapper = $contentDataMapper;
-        $this->entityClass = $entityClass;
+        $this->contentRichEntityClass = $contentRichEntityClass;
     }
 
     /**
@@ -70,7 +73,7 @@ class ContentObjectProvider implements PreviewObjectProviderInterface
             /** @var ContentRichEntityInterface $contentRichEntity */
             $contentRichEntity = $this->entityManager->createQueryBuilder()
                 ->select('entity')
-                ->from($this->entityClass, 'entity')
+                ->from($this->contentRichEntityClass, 'entity')
                 ->where('entity.id = :id')
                 ->setParameter('id', $id)
                 ->getQuery()

--- a/Content/Infrastructure/Sulu/Sitemap/ContentSitemapProvider.php
+++ b/Content/Infrastructure/Sulu/Sitemap/ContentSitemapProvider.php
@@ -52,14 +52,14 @@ class ContentSitemapProvider implements SitemapProviderInterface
     protected $kernelEnvironment;
 
     /**
-     * @var string
+     * @var class-string
      */
-    protected $entityClassName;
+    protected $contentClass;
 
     /**
-     * @var string
+     * @var class-string
      */
-    protected $routeClassName;
+    protected $routeClass;
 
     /**
      * @var string
@@ -68,21 +68,22 @@ class ContentSitemapProvider implements SitemapProviderInterface
 
     /**
      * @param string $kernelEnvironment Inject parameter "kernel.environment" here
-     * @param string $entityClassName Classname that's used in the route table
+     * @param class-string $contentClass Classname that is used in the route table
+     * @param class-string $routeClass
      */
     public function __construct(
         EntityManagerInterface $entityManager,
         WebspaceManagerInterface $webspaceManager,
         string $kernelEnvironment,
-        string $entityClassName,
-        string $routeClassName,
+        string $contentClass,
+        string $routeClass,
         string $alias
     ) {
         $this->entityManager = $entityManager;
         $this->webspaceManager = $webspaceManager;
         $this->kernelEnvironment = $kernelEnvironment;
-        $this->entityClassName = $entityClassName;
-        $this->routeClassName = $routeClassName;
+        $this->contentClass = $contentClass;
+        $this->routeClass = $routeClass;
         $this->alias = $alias;
     }
 
@@ -205,17 +206,17 @@ class ContentSitemapProvider implements SitemapProviderInterface
         $queryBuilder = $this->entityManager->createQueryBuilder();
 
         return $queryBuilder
-            ->from($this->entityClassName, self::CONTENT_RICH_ENTITY_ALIAS)
+            ->from($this->contentClass, self::CONTENT_RICH_ENTITY_ALIAS)
             ->innerJoin(self::CONTENT_RICH_ENTITY_ALIAS . '.dimensionContents', self::LOCALIZED_DIMENSION_CONTENT_ALIAS)
             ->innerJoin(self::LOCALIZED_DIMENSION_CONTENT_ALIAS . '.dimension', self::LOCALIZED_DIMENSION_ALIAS)
-            ->innerJoin($this->routeClassName, self::ROUTE_ALIAS, Join::WITH, self::ROUTE_ALIAS . '.entityId = ' . self::CONTENT_RICH_ENTITY_ALIAS . '.' . $this->getEntityIdField())
+            ->innerJoin($this->routeClass, self::ROUTE_ALIAS, Join::WITH, self::ROUTE_ALIAS . '.entityId = ' . self::CONTENT_RICH_ENTITY_ALIAS . '.' . $this->getEntityIdField())
             ->where(self::LOCALIZED_DIMENSION_ALIAS . '.stage = :stage')
             ->andWhere(self::ROUTE_ALIAS . '.entityClass = :entityClass')
             ->andWhere(self::ROUTE_ALIAS . '.history = :history')
             ->andWhere(self::ROUTE_ALIAS . '.locale = ' . self::LOCALIZED_DIMENSION_ALIAS . '.locale')
             ->setParameters([
                 'stage' => DimensionInterface::STAGE_LIVE,
-                'entityClass' => $this->entityClassName,
+                'entityClass' => $this->contentClass,
                 'history' => false,
             ]);
     }

--- a/Content/Infrastructure/Sulu/SmartContent/Repository/ContentDataProviderRepository.php
+++ b/Content/Infrastructure/Sulu/SmartContent/Repository/ContentDataProviderRepository.php
@@ -46,31 +46,31 @@ class ContentDataProviderRepository implements DataProviderRepositoryInterface
     protected $showDrafts;
 
     /**
-     * @var string
+     * @var class-string<ContentRichEntityInterface>
      */
-    protected $entityClassName;
+    protected $contentRichEntityClass;
 
     /**
      * @var ClassMetadata
      */
-    protected $entityClassMetadata;
+    protected $contentRichEntityClassMetadata;
 
     /**
      * @param bool $showDrafts Inject parameter "sulu_document_manager.show_drafts" here
-     * @param class-string<ContentRichEntityInterface> $entityClassName
+     * @param class-string<ContentRichEntityInterface> $contentRichEntityClass
      */
     public function __construct(
         ContentManagerInterface $contentManager,
         EntityManagerInterface $entityManager,
         bool $showDrafts,
-        string $entityClassName
+        string $contentRichEntityClass
     ) {
         $this->contentManager = $contentManager;
         $this->entityManager = $entityManager;
         $this->showDrafts = $showDrafts;
-        $this->entityClassName = $entityClassName;
+        $this->contentRichEntityClass = $contentRichEntityClass;
 
-        $this->entityClassMetadata = $this->entityManager->getClassMetadata($this->entityClassName);
+        $this->contentRichEntityClassMetadata = $this->entityManager->getClassMetadata($this->contentRichEntityClass);
     }
 
     /**
@@ -419,7 +419,7 @@ class ContentDataProviderRepository implements DataProviderRepositoryInterface
         return $this->entityManager->createQueryBuilder()
             ->select(self::CONTENT_RICH_ENTITY_ALIAS . '.' . $this->getEntityIdentifierFieldName() . ' as id')
             ->distinct()
-            ->from($this->entityClassName, self::CONTENT_RICH_ENTITY_ALIAS)
+            ->from($this->contentRichEntityClass, self::CONTENT_RICH_ENTITY_ALIAS)
             ->innerJoin(self::CONTENT_RICH_ENTITY_ALIAS . '.dimensionContents', self::LOCALIZED_DIMENSION_CONTENT_ALIAS)
             ->innerJoin(self::LOCALIZED_DIMENSION_CONTENT_ALIAS . '.dimension', self::LOCALIZED_DIMENSION_ALIAS)
             ->andWhere(self::LOCALIZED_DIMENSION_ALIAS . '.stage = (:stage)')
@@ -443,7 +443,7 @@ class ContentDataProviderRepository implements DataProviderRepositoryInterface
 
         $entities = $this->entityManager->createQueryBuilder()
             ->select(self::CONTENT_RICH_ENTITY_ALIAS)
-            ->from($this->entityClassName, self::CONTENT_RICH_ENTITY_ALIAS)
+            ->from($this->contentRichEntityClass, self::CONTENT_RICH_ENTITY_ALIAS)
             ->where(self::CONTENT_RICH_ENTITY_ALIAS . '.' . $entityIdentifierFieldName . ' IN (:ids)')
             ->getQuery()
             ->setParameter('ids', $ids)
@@ -454,8 +454,8 @@ class ContentDataProviderRepository implements DataProviderRepositoryInterface
         usort(
             $entities,
             function (ContentRichEntityInterface $a, ContentRichEntityInterface $b) use ($idPositions, $entityIdentifierFieldName) {
-                $aId = $this->entityClassMetadata->getIdentifierValues($a)[$entityIdentifierFieldName];
-                $bId = $this->entityClassMetadata->getIdentifierValues($b)[$entityIdentifierFieldName];
+                $aId = $this->contentRichEntityClassMetadata->getIdentifierValues($a)[$entityIdentifierFieldName];
+                $bId = $this->contentRichEntityClassMetadata->getIdentifierValues($b)[$entityIdentifierFieldName];
 
                 return $idPositions[$aId] - $idPositions[$bId];
             }
@@ -469,6 +469,6 @@ class ContentDataProviderRepository implements DataProviderRepositoryInterface
      */
     protected function getEntityIdentifierFieldName(): string
     {
-        return $this->entityClassMetadata->getSingleIdentifierFieldName();
+        return $this->contentRichEntityClassMetadata->getSingleIdentifierFieldName();
     }
 }

--- a/Content/Infrastructure/Sulu/Teaser/ContentTeaserProvider.php
+++ b/Content/Infrastructure/Sulu/Teaser/ContentTeaserProvider.php
@@ -46,20 +46,23 @@ abstract class ContentTeaserProvider implements TeaserProviderInterface
     protected $metadataFactory;
 
     /**
-     * @var string
+     * @var class-string<ContentRichEntityInterface>
      */
-    protected $entityClassName;
+    protected $contentRichEntityClass;
 
+    /**
+     * @param class-string<ContentRichEntityInterface> $contentRichEntityClass
+     */
     public function __construct(
         ContentManagerInterface $contentManager,
         EntityManagerInterface $entityManager,
         StructureMetadataFactoryInterface $metadataFactory,
-        string $entityClassName
+        string $contentRichEntityClass
     ) {
         $this->contentManager = $contentManager;
         $this->entityManager = $entityManager;
         $this->metadataFactory = $metadataFactory;
-        $this->entityClassName = $entityClassName;
+        $this->contentRichEntityClass = $contentRichEntityClass;
     }
 
     /**
@@ -262,11 +265,11 @@ abstract class ContentTeaserProvider implements TeaserProviderInterface
     protected function findEntitiesByIds(array $ids): array
     {
         $entityIdField = $this->getEntityIdField();
-        $classMetadata = $this->entityManager->getClassMetadata($this->entityClassName);
+        $classMetadata = $this->entityManager->getClassMetadata($this->contentRichEntityClass);
 
         $entities = $this->entityManager->createQueryBuilder()
             ->select(self::CONTENT_RICH_ENTITY_ALIAS)
-            ->from($this->entityClassName, self::CONTENT_RICH_ENTITY_ALIAS)
+            ->from($this->contentRichEntityClass, self::CONTENT_RICH_ENTITY_ALIAS)
             ->where(self::CONTENT_RICH_ENTITY_ALIAS . '.' . $entityIdField . ' IN (:ids)')
             ->getQuery()
             ->setParameter('ids', $ids)
@@ -294,13 +297,10 @@ abstract class ContentTeaserProvider implements TeaserProviderInterface
 
     protected function getResourceKey(): string
     {
-        /** @var class-string<ContentRichEntityInterface> $entityClassName */
-        $entityClassName = $this->entityClassName;
-
-        $resourceKey = $entityClassName::getResourceKey();
+        $resourceKey = $this->contentRichEntityClass::getResourceKey();
 
         if (!$resourceKey) {
-            throw new \RuntimeException(sprintf('Error while calling "%s".', $this->entityClassName . '::getResourceKey'));
+            throw new \RuntimeException(sprintf('Error while calling "%s".', $this->contentRichEntityClass . '::getResourceKey'));
         }
 
         return $resourceKey;

--- a/Tests/Unit/Content/Infrastructure/Sulu/Admin/ContentViewBuilderFactoryTest.php
+++ b/Tests/Unit/Content/Infrastructure/Sulu/Admin/ContentViewBuilderFactoryTest.php
@@ -21,6 +21,7 @@ use Sulu\Bundle\AdminBundle\Admin\View\PreviewFormViewBuilderInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactory;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\ContentDataMapperInterface;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\ContentResolverInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentRichEntityInterface;
 use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Admin\ContentViewBuilderFactory;
 use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Admin\ContentViewBuilderFactoryInterface;
 use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Preview\ContentObjectProvider;
@@ -59,6 +60,9 @@ class ContentViewBuilderFactoryTest extends TestCase
         return new PreviewObjectProviderRegistry($providers);
     }
 
+    /**
+     * @param class-string<ContentRichEntityInterface> $entityClass
+     */
     protected function createContentObjectProvider(
         EntityManagerInterface $entityManager,
         ContentResolverInterface $contentResolver,


### PR DESCRIPTION
I think we should use a consistent argument name for the `$contentRichEntityClass` argument 🙂
