### PR TITLE
Rename getRoutableId method of RoutableInterface to getResourceId

### DIFF
--- a/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapper.php
@@ -110,7 +110,7 @@ class RoutableDataMapper implements DataMapperInterface
             return;
         }
 
-        if (!$localizedObject->getRoutableId()) {
+        if (!$localizedObject->getResourceId()) {
             // FIXME the code only works if the entity is flushed once and has a valid id
 
             return;
@@ -167,7 +167,7 @@ class RoutableDataMapper implements DataMapperInterface
 
         $route = $this->routeManager->createOrUpdateByAttributes(
             $entityClass,
-            (string) $localizedObject->getRoutableId(),
+            (string) $localizedObject->getResourceId(),
             $locale,
             $routePath
         );

--- a/Content/Application/ContentNormalizer/Normalizer/RoutableNormalizer.php
+++ b/Content/Application/ContentNormalizer/Normalizer/RoutableNormalizer.php
@@ -33,7 +33,7 @@ class RoutableNormalizer implements NormalizerInterface
         }
 
         return [
-            'routableId',
+            'resourceId',
         ];
     }
 }

--- a/Content/Domain/Model/RoutableInterface.php
+++ b/Content/Domain/Model/RoutableInterface.php
@@ -23,7 +23,7 @@ interface RoutableInterface
     /**
      * @return mixed
      */
-    public function getRoutableId();
+    public function getResourceId();
 
     public function getLocale(): ?string;
 }

--- a/Content/Domain/Model/RoutableTrait.php
+++ b/Content/Domain/Model/RoutableTrait.php
@@ -20,7 +20,7 @@ trait RoutableTrait
         return $this->getDimension()->getLocale();
     }
 
-    public function getRoutableId()
+    public function getResourceId()
     {
         return $this->getContentRichEntity()->getId();
     }

--- a/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapperTest.php
+++ b/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapperTest.php
@@ -143,7 +143,7 @@ class RoutableDataMapperTest extends TestCase
         $factory->getStructureMetadata(Argument::cetera())->shouldNotBeCalled();
         $routeManager->createOrUpdateByAttributes(Argument::cetera())->shouldNotBeCalled();
         $conflictResolver->resolve(Argument::cetera())->shouldNotBeCalled();
-        $localizedDimensionContent->getRoutableId()->shouldNotBeCalled();
+        $localizedDimensionContent->getResourceId()->shouldNotBeCalled();
         $localizedDimensionContent->setTemplateData(Argument::cetera())->shouldNotBeCalled();
 
         $mapper = $this->createRouteDataMapperInstance(
@@ -175,7 +175,7 @@ class RoutableDataMapperTest extends TestCase
         $factory->getStructureMetadata(Argument::cetera())->shouldNotBeCalled();
         $routeManager->createOrUpdateByAttributes(Argument::cetera())->shouldNotBeCalled();
         $conflictResolver->resolve(Argument::cetera())->shouldNotBeCalled();
-        $localizedDimensionContent->getRoutableId()->shouldNotBeCalled();
+        $localizedDimensionContent->getResourceId()->shouldNotBeCalled();
         $localizedDimensionContent->setTemplateData(Argument::cetera())->shouldNotBeCalled();
 
         $mapper = $this->createRouteDataMapperInstance(
@@ -255,7 +255,7 @@ class RoutableDataMapperTest extends TestCase
 
         $metadata->getProperties()->WillReturn([$property->reveal()]);
 
-        $localizedDimensionContent->getRoutableId()->willReturn('123-123-123');
+        $localizedDimensionContent->getResourceId()->willReturn('123-123-123');
         $localizedDimensionContent->getLocale()->willReturn('de');
         $factory->getStructureMetadata('mock-template-type', 'default')->willReturn($metadata->reveal())->shouldBeCalled();
 
@@ -300,7 +300,7 @@ class RoutableDataMapperTest extends TestCase
 
         $metadata->getProperties()->WillReturn([$property->reveal()]);
 
-        $localizedDimensionContent->getRoutableId()->willReturn('123-123-123');
+        $localizedDimensionContent->getResourceId()->willReturn('123-123-123');
         $localizedDimensionContent->getTemplateData()->willReturn(['url' => '/test']);
         $localizedDimensionContent->getLocale()->willReturn('de');
         $factory->getStructureMetadata('mock-template-type', 'default')->willReturn($metadata->reveal())->shouldBeCalled();
@@ -342,7 +342,7 @@ class RoutableDataMapperTest extends TestCase
 
         $metadata->getProperties()->WillReturn([$property->reveal()]);
 
-        $localizedDimensionContent->getRoutableId()->willReturn('123-123-123');
+        $localizedDimensionContent->getResourceId()->willReturn('123-123-123');
         $localizedDimensionContent->getTemplateData()->willReturn([]);
         $localizedDimensionContent->getLocale()->willReturn('en');
         $localizedDimensionContent->setTemplateData(['url' => '/test'])->shouldBeCalled();
@@ -407,7 +407,7 @@ class RoutableDataMapperTest extends TestCase
 
         $metadata->getProperties()->WillReturn([$property->reveal()]);
 
-        $localizedDimensionContent->getRoutableId()->willReturn('123-123-123');
+        $localizedDimensionContent->getResourceId()->willReturn('123-123-123');
         $localizedDimensionContent->getTemplateData()->willReturn([]);
         $localizedDimensionContent->getLocale()->willReturn('en');
         $localizedDimensionContent->setTemplateData(Argument::cetera())->shouldNotBeCalled();
@@ -469,7 +469,7 @@ class RoutableDataMapperTest extends TestCase
 
         $factory->getStructureMetadata('mock-template-type', 'default')->willReturn($metadata->reveal())->shouldBeCalled();
 
-        $localizedDimensionContent->getRoutableId()->willReturn(null);
+        $localizedDimensionContent->getResourceId()->willReturn(null);
 
         $mapper = $this->createRouteDataMapperInstance(
             $factory->reveal(),
@@ -513,7 +513,7 @@ class RoutableDataMapperTest extends TestCase
 
         $factory->getStructureMetadata('mock-template-type', 'default')->willReturn($metadata->reveal())->shouldBeCalled();
 
-        $localizedDimensionContent->getRoutableId()->willReturn('123-123-123');
+        $localizedDimensionContent->getResourceId()->willReturn('123-123-123');
         $localizedDimensionContent->getLocale()->willReturn(null);
 
         $mapper = $this->createRouteDataMapperInstance(
@@ -556,7 +556,7 @@ class RoutableDataMapperTest extends TestCase
 
         $factory->getStructureMetadata('mock-template-type', 'default')->willReturn($metadata->reveal())->shouldBeCalled();
 
-        $localizedDimensionContent->getRoutableId()->willReturn('123-123-123');
+        $localizedDimensionContent->getResourceId()->willReturn('123-123-123');
         $localizedDimensionContent->getTemplateData()->willReturn(['title' => 'Test', 'url' => null]);
         $localizedDimensionContent->getLocale()->willReturn('en');
 
@@ -623,7 +623,7 @@ class RoutableDataMapperTest extends TestCase
         $localizedDimensionContent->getTemplateData()->willReturn([]);
         $factory->getStructureMetadata('mock-template-type', 'default')->willReturn($metadata->reveal())->shouldBeCalled();
 
-        $localizedDimensionContent->getRoutableId()->willReturn('123-123-123');
+        $localizedDimensionContent->getResourceId()->willReturn('123-123-123');
         $localizedDimensionContent->getLocale()->willReturn('en');
         $localizedDimensionContentMock = $this->wrapRoutableMock($localizedDimensionContent);
 
@@ -682,7 +682,7 @@ class RoutableDataMapperTest extends TestCase
         $localizedDimensionContent->getTemplateData()->willReturn([]);
         $factory->getStructureMetadata('mock-template-type', 'default')->willReturn($metadata->reveal())->shouldBeCalled();
 
-        $localizedDimensionContent->getRoutableId()->willReturn('123-123-123');
+        $localizedDimensionContent->getResourceId()->willReturn('123-123-123');
         $localizedDimensionContent->getLocale()->willReturn('en');
         $localizedDimensionContentMock = $this->wrapRoutableMock($localizedDimensionContent);
 
@@ -741,7 +741,7 @@ class RoutableDataMapperTest extends TestCase
         $localizedDimensionContent->getTemplateData()->willReturn([]);
         $factory->getStructureMetadata('mock-template-type', 'default')->willReturn($metadata->reveal())->shouldBeCalled();
 
-        $localizedDimensionContent->getRoutableId()->willReturn('123-123-123');
+        $localizedDimensionContent->getResourceId()->willReturn('123-123-123');
         $localizedDimensionContent->getLocale()->willReturn('en');
         $localizedDimensionContentMock = $this->wrapRoutableMock($localizedDimensionContent);
 
@@ -800,7 +800,7 @@ class RoutableDataMapperTest extends TestCase
 
         $factory->getStructureMetadata('mock-template-type', 'default')->willReturn($metadata->reveal())->shouldBeCalled();
 
-        $localizedDimensionContent->getRoutableId()->willReturn('123-123-123');
+        $localizedDimensionContent->getResourceId()->willReturn('123-123-123');
         $localizedDimensionContent->getTemplateData()->willReturn(['title' => 'Test', 'url' => null]);
         $localizedDimensionContent->getLocale()->willReturn('en');
         $localizedDimensionContentMock = $this->wrapRoutableMock($localizedDimensionContent);
@@ -810,7 +810,7 @@ class RoutableDataMapperTest extends TestCase
                 '_unlocalizedObject' => $dimensionContent->reveal(),
                 '_localizedObject' => $localizedDimensionContentMock,
             ]),
-            ['route_schema' => 'custom/{object["_localizedObject"].getName()}-{object["_unlocalizedObject"].getRoutableId()}']
+            ['route_schema' => 'custom/{object["_localizedObject"].getName()}-{object["_unlocalizedObject"].getResourceId()}']
         )->willReturn('/custom/testEntity-123');
 
         $route = $this->prophesize(RouteInterface::class);
@@ -835,7 +835,7 @@ class RoutableDataMapperTest extends TestCase
                 'mock-resource-key' => [
                     'generator' => 'schema',
                     'options' => [
-                        'route_schema' => 'custom/{object["_localizedObject"].getName()}-{object["_unlocalizedObject"].getRoutableId()}',
+                        'route_schema' => 'custom/{object["_localizedObject"].getName()}-{object["_unlocalizedObject"].getResourceId()}',
                     ],
                     'resource_key' => 'mock-resource-key',
                     'entityClass' => 'Sulu/Test/TestEntity',

--- a/Tests/Unit/Content/Application/ContentNormalizer/Normalizer/RoutableNormalizerTest.php
+++ b/Tests/Unit/Content/Application/ContentNormalizer/Normalizer/RoutableNormalizerTest.php
@@ -42,7 +42,7 @@ class RoutableNormalizerTest extends TestCase
 
         $this->assertSame(
             [
-                'routableId',
+                'resourceId',
             ],
             $normalizer->getIgnoredAttributes($object->reveal())
         );

--- a/Tests/Unit/Content/Domain/Model/RoutableTraitTest.php
+++ b/Tests/Unit/Content/Domain/Model/RoutableTraitTest.php
@@ -71,9 +71,9 @@ class RoutableTraitTest extends TestCase
         $this->assertSame('en', $model->getLocale());
     }
 
-    public function testGetRoutableId(): void
+    public function testGetResourceId(): void
     {
         $model = $this->getRoutableInstance();
-        $this->assertSame('content-id-123', $model->getRoutableId());
+        $this->assertSame('content-id-123', $model->getResourceId());
     }
 }

--- a/Tests/Unit/Mocks/RoutableMockWrapperTrait.php
+++ b/Tests/Unit/Mocks/RoutableMockWrapperTrait.php
@@ -25,9 +25,9 @@ trait RoutableMockWrapperTrait
         return 'mock-resource-key';
     }
 
-    public function getRoutableId()
+    public function getResourceId()
     {
-        return $this->instance->getRoutableId();
+        return $this->instance->getResourceId();
     }
 
     public function getLocale(): ?string

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,11 @@
 
 ## dev-master
 
+### Rename getRoutableId method of RoutableInterface to getResourceId
+
+The `getRoutableId` method of the `RoutableInterface` was renamed to `getResourceId`. This makes the naming consistent 
+with the `getResourceKey` method of the `RoutableInterface` and the `DimensionContentInterface`.
+
 ### Add contentRichEntityClass parameter to getDefaultToolbarActions method of ContentViewBuilderFactory
 
 The `getDefaultToolbarActions` method of the `ContentViewBuilderFactory` has a required `contentRichEntityClass` parameter


### PR DESCRIPTION
This makes the naming consistent with the `getResourceKey` method of the `RoutableInterface` and the `DimensionContentInterface`.