### PR TITLE
Rename getContentRichEntity method of DimensionContentInterface to getResource

### DIFF
--- a/Content/Application/ContentMerger/ContentMerger.php
+++ b/Content/Application/ContentMerger/ContentMerger.php
@@ -44,7 +44,7 @@ class ContentMerger implements ContentMergerInterface
 
         $mostSpecificDimensionContent = $dimensionContentCollectionArray[$lastKey];
         $mostSpecificDimension = $mostSpecificDimensionContent->getDimension();
-        $contentRichEntity = $mostSpecificDimensionContent->getContentRichEntity();
+        $contentRichEntity = $mostSpecificDimensionContent->getResource();
 
         $mergedDimensionContent = $contentRichEntity->createDimensionContent($mostSpecificDimension);
         $mergedDimensionContent->markAsMerged();

--- a/Content/Application/ContentNormalizer/Normalizer/DimensionContentNormalizer.php
+++ b/Content/Application/ContentNormalizer/Normalizer/DimensionContentNormalizer.php
@@ -27,7 +27,7 @@ class DimensionContentNormalizer implements NormalizerInterface
             'id',
             'merged',
             'dimension',
-            'contentRichEntity',
+            'resource',
         ];
     }
 
@@ -37,7 +37,7 @@ class DimensionContentNormalizer implements NormalizerInterface
             return $normalizedData;
         }
 
-        $normalizedData['id'] = $object->getContentRichEntity()->getId();
+        $normalizedData['id'] = $object->getResource()->getId();
         $normalizedData['locale'] = $object->getDimension()->getLocale();
         $normalizedData['stage'] = $object->getDimension()->getStage();
 

--- a/Content/Domain/Model/DimensionContentInterface.php
+++ b/Content/Domain/Model/DimensionContentInterface.php
@@ -19,7 +19,7 @@ interface DimensionContentInterface
 
     public function getDimension(): DimensionInterface;
 
-    public function getContentRichEntity(): ContentRichEntityInterface;
+    public function getResource(): ContentRichEntityInterface;
 
     public function isMerged(): bool;
 

--- a/Content/Domain/Model/RoutableTrait.php
+++ b/Content/Domain/Model/RoutableTrait.php
@@ -22,10 +22,10 @@ trait RoutableTrait
 
     public function getResourceId()
     {
-        return $this->getContentRichEntity()->getId();
+        return $this->getResource()->getId();
     }
 
     abstract public function getDimension(): DimensionInterface;
 
-    abstract public function getContentRichEntity(): ContentRichEntityInterface;
+    abstract public function getResource(): ContentRichEntityInterface;
 }

--- a/Content/Infrastructure/Sulu/Preview/ContentObjectProvider.php
+++ b/Content/Infrastructure/Sulu/Preview/ContentObjectProvider.php
@@ -92,7 +92,7 @@ class ContentObjectProvider implements PreviewObjectProviderInterface
      */
     public function getId($object)
     {
-        return $object->getContentRichEntity()->getId();
+        return $object->getResource()->getId();
     }
 
     /**
@@ -129,7 +129,7 @@ class ContentObjectProvider implements PreviewObjectProviderInterface
     public function serialize($object)
     {
         return json_encode([
-            'id' => $object->getContentRichEntity()->getId(),
+            'id' => $object->getResource()->getId(),
             'locale' => $object->getDimension()->getLocale(),
         ]) ?: '[]';
     }

--- a/Content/Infrastructure/Sulu/SmartContent/DataItem/ContentDataItem.php
+++ b/Content/Infrastructure/Sulu/SmartContent/DataItem/ContentDataItem.php
@@ -32,7 +32,7 @@ class ContentDataItem extends ArrayAccessItem implements ItemInterface, PublishI
     public function __construct(DimensionContentInterface $dimensionContent, array $data)
     {
         parent::__construct(
-            $dimensionContent->getContentRichEntity()->getId(),
+            $dimensionContent->getResource()->getId(),
             $data,
             $dimensionContent
         );

--- a/Content/Infrastructure/Sulu/SmartContent/Provider/ContentDataProvider.php
+++ b/Content/Infrastructure/Sulu/SmartContent/Provider/ContentDataProvider.php
@@ -119,7 +119,7 @@ class ContentDataProvider extends BaseDataProvider
      */
     protected function getIdForItem($dimensionContent)
     {
-        return $dimensionContent->getContentRichEntity()->getId();
+        return $dimensionContent->getResource()->getId();
     }
 
     /**

--- a/Content/Infrastructure/Sulu/Teaser/ContentTeaserProvider.php
+++ b/Content/Infrastructure/Sulu/Teaser/ContentTeaserProvider.php
@@ -123,7 +123,7 @@ abstract class ContentTeaserProvider implements TeaserProviderInterface
         $mediaId = $this->getMediaId($dimensionContent, $data);
 
         return new Teaser(
-            $dimensionContent->getContentRichEntity()->getId(),
+            $dimensionContent->getResource()->getId(),
             $this->getResourceKey(),
             $locale,
             $title,

--- a/Tests/Application/ExampleTestBundle/Entity/ExampleDimensionContent.php
+++ b/Tests/Application/ExampleTestBundle/Entity/ExampleDimensionContent.php
@@ -66,7 +66,7 @@ class ExampleDimensionContent implements DimensionContentInterface, ExcerptInter
         return $this->id;
     }
 
-    public function getContentRichEntity(): ContentRichEntityInterface
+    public function getResource(): ContentRichEntityInterface
     {
         return $this->example;
     }

--- a/Tests/Functional/Content/Infrastructure/Sulu/Sitemap/ContentSitemapProviderTest.php
+++ b/Tests/Functional/Content/Infrastructure/Sulu/Sitemap/ContentSitemapProviderTest.php
@@ -42,28 +42,28 @@ class ContentSitemapProviderTest extends BaseTestCase
         parent::setUpBeforeClass();
 
         // Example 1 (both locales, both published)
-        $example1 = static::createExample(['title' => 'example-1'], 'en')->getContentRichEntity();
+        $example1 = static::createExample(['title' => 'example-1'], 'en')->getResource();
         static::publishExample($example1->getId(), 'en');
 
         static::modifyExample($example1->getId(), ['title' => 'beispiel-1'], 'de');
         static::publishExample($example1->getId(), 'de');
 
         // Example 2 (only en, published)
-        $example2 = static::createExample(['title' => 'example-2'], 'en')->getContentRichEntity();
+        $example2 = static::createExample(['title' => 'example-2'], 'en')->getResource();
         static::publishExample($example2->getId(), 'en');
 
         // Example 3 (both locales, only en published)
-        $example3 = static::createExample(['title' => 'example-3'], 'en')->getContentRichEntity();
+        $example3 = static::createExample(['title' => 'example-3'], 'en')->getResource();
         static::publishExample($example3->getId(), 'en');
 
         static::modifyExample($example3->getId(), ['title' => 'beispiel-3'], 'de');
 
         // Example 4 (only de, published)
-        $example4 = static::createExample(['title' => 'beispiel-4'], 'de')->getContentRichEntity();
+        $example4 = static::createExample(['title' => 'beispiel-4'], 'de')->getResource();
         static::publishExample($example4->getId(), 'de');
 
         // Example 5 (only en, not published)
-        $example5 = static::createExample(['title' => 'example-5'], 'en')->getContentRichEntity();
+        $example5 = static::createExample(['title' => 'example-5'], 'en')->getResource();
     }
 
     public function setUp(): void

--- a/Tests/Functional/Content/Infrastructure/Sulu/SmartContent/ContentDataProviderTest.php
+++ b/Tests/Functional/Content/Infrastructure/Sulu/SmartContent/ContentDataProviderTest.php
@@ -85,7 +85,7 @@ class ContentDataProviderTest extends BaseTestCase
             'title' => 'example without categories without tags',
             'excerptCategories' => [],
             'excerptTags' => [],
-        ], 'en')->getContentRichEntity();
+        ], 'en')->getResource();
         static::publishExample($example1->getId(), 'en');
         static::modifyExample($example1->getId(), [
             'title' => 'example without categories without tags',
@@ -112,7 +112,7 @@ class ContentDataProviderTest extends BaseTestCase
                 static::$categoryFoo->getId(),
             ],
             'excerptTags' => [],
-        ], 'en')->getContentRichEntity();
+        ], 'en')->getResource();
         static::publishExample($example2->getId(), 'en');
         static::modifyExample($example2->getId(), [
             'title' => 'example with some categories without tags unpublished',
@@ -131,7 +131,7 @@ class ContentDataProviderTest extends BaseTestCase
                 static::$categoryBaz->getId(),
             ],
             'excerptTags' => [],
-        ], 'en')->getContentRichEntity();
+        ], 'en')->getResource();
         static::publishExample($example3->getId(), 'en');
         static::modifyExample($example3->getId(), [
             'title' => 'example with all categories without tags',
@@ -151,7 +151,7 @@ class ContentDataProviderTest extends BaseTestCase
             'excerptTags' => [
                 'tagA',
             ],
-        ], 'en')->getContentRichEntity();
+        ], 'en')->getResource();
         static::publishExample($example4->getId(), 'en');
         static::modifyExample($example4->getId(), [
             'title' => 'example without categories with some tags',
@@ -171,7 +171,7 @@ class ContentDataProviderTest extends BaseTestCase
                 'tagB',
                 'tagC',
             ],
-        ], 'en')->getContentRichEntity();
+        ], 'en')->getResource();
         static::publishExample($example5->getId(), 'en');
         static::modifyExample($example5->getId(), [
             'title' => 'example without categories with all tags',
@@ -193,7 +193,7 @@ class ContentDataProviderTest extends BaseTestCase
             'excerptTags' => [
                 'tagB',
             ],
-        ], 'en')->getContentRichEntity();
+        ], 'en')->getResource();
         static::publishExample($example6->getId(), 'en');
         static::modifyExample($example6->getId(), [
             'title' => 'example with some categories with some tags',
@@ -219,7 +219,7 @@ class ContentDataProviderTest extends BaseTestCase
                 'tagB',
                 'tagC',
             ],
-        ], 'en')->getContentRichEntity();
+        ], 'en')->getResource();
         static::publishExample($example7->getId(), 'en');
         static::modifyExample($example7->getId(), [
             'title' => 'example with all categories with all tags',

--- a/Tests/Functional/Content/Infrastructure/Sulu/Teaser/ContentTeaserProviderTest.php
+++ b/Tests/Functional/Content/Infrastructure/Sulu/Teaser/ContentTeaserProviderTest.php
@@ -47,7 +47,7 @@ class ContentTeaserProviderTest extends BaseTestCase
             'article' => 'example-1-article',
             'excerptTitle' => 'example-1-excerpt-title',
             'excerptDescription' => 'example-1-excerpt-description',
-        ], 'en')->getContentRichEntity();
+        ], 'en')->getResource();
         static::publishExample($example1->getId(), 'en');
 
         static::modifyExample($example1->getId(), [
@@ -60,13 +60,13 @@ class ContentTeaserProviderTest extends BaseTestCase
         static::$exampleIds[] = $example1->getId();
 
         // Example 2 (only en, published)
-        $example2 = static::createExample(['title' => 'example-2'], 'en')->getContentRichEntity();
+        $example2 = static::createExample(['title' => 'example-2'], 'en')->getResource();
         static::publishExample($example2->getId(), 'en');
 
         static::$exampleIds[] = $example2->getId();
 
         // Example 3 (both locales, only en published)
-        $example3 = static::createExample(['title' => 'example-3'], 'en')->getContentRichEntity();
+        $example3 = static::createExample(['title' => 'example-3'], 'en')->getResource();
         static::publishExample($example3->getId(), 'en');
 
         static::modifyExample($example3->getId(), ['title' => 'beispiel-3'], 'de');
@@ -74,13 +74,13 @@ class ContentTeaserProviderTest extends BaseTestCase
         static::$exampleIds[] = $example3->getId();
 
         // Example 4 (only de, published)
-        $example4 = static::createExample(['title' => 'beispiel-4'], 'de')->getContentRichEntity();
+        $example4 = static::createExample(['title' => 'beispiel-4'], 'de')->getResource();
         static::publishExample($example4->getId(), 'de');
 
         static::$exampleIds[] = $example4->getId();
 
         // Example 5 (only en, not published)
-        $example5 = static::createExample(['title' => 'example-5'], 'en')->getContentRichEntity();
+        $example5 = static::createExample(['title' => 'example-5'], 'en')->getResource();
 
         static::$exampleIds[] = $example5->getId();
     }

--- a/Tests/Unit/Content/Application/ContentMerger/ContentMergerTest.php
+++ b/Tests/Unit/Content/Application/ContentMerger/ContentMergerTest.php
@@ -51,12 +51,12 @@ class ContentMergerTest extends TestCase
 
         $mostSpecificDimension = $this->prophesize(DimensionInterface::class);
 
-        $contentRichEntity = $this->prophesize(ContentRichEntityInterface::class);
-        $contentRichEntity->createDimensionContent($mostSpecificDimension->reveal())
+        $resource = $this->prophesize(ContentRichEntityInterface::class);
+        $resource->createDimensionContent($mostSpecificDimension->reveal())
             ->willReturn($mergedDimensionContent->reveal());
 
         $dimensionContent3->getDimension()->willReturn($mostSpecificDimension->reveal());
-        $dimensionContent3->getContentRichEntity()->willReturn($contentRichEntity->reveal());
+        $dimensionContent3->getResource()->willReturn($resource->reveal());
 
         $merger1->merge($mergedDimensionContent->reveal(), $dimensionContent1->reveal())->shouldBeCalled();
         $merger2->merge($mergedDimensionContent->reveal(), $dimensionContent1->reveal())->shouldBeCalled();

--- a/Tests/Unit/Content/Application/ContentNormalizer/ContentNormalizerTest.php
+++ b/Tests/Unit/Content/Application/ContentNormalizer/ContentNormalizerTest.php
@@ -66,11 +66,11 @@ class ContentNormalizerTest extends TestCase
             /**
              * @var ContentRichEntityInterface
              */
-            protected $contentRichEntity;
+            protected $resource;
 
-            public function __construct(ContentRichEntityInterface $contentRichEntity, DimensionInterface $dimension)
+            public function __construct(ContentRichEntityInterface $resource, DimensionInterface $dimension)
             {
-                $this->contentRichEntity = $contentRichEntity;
+                $this->resource = $resource;
                 $this->dimension = $dimension;
             }
 
@@ -79,9 +79,9 @@ class ContentNormalizerTest extends TestCase
                 throw new \RuntimeException('Should not be called while executing tests.');
             }
 
-            public function getContentRichEntity(): ContentRichEntityInterface
+            public function getResource(): ContentRichEntityInterface
             {
-                return $this->contentRichEntity;
+                return $this->resource;
             }
         };
 
@@ -113,11 +113,11 @@ class ContentNormalizerTest extends TestCase
             /**
              * @var ContentRichEntityInterface
              */
-            protected $contentRichEntity;
+            protected $resource;
 
-            public function __construct(ContentRichEntityInterface $contentRichEntity, DimensionInterface $dimension)
+            public function __construct(ContentRichEntityInterface $resource, DimensionInterface $dimension)
             {
-                $this->contentRichEntity = $contentRichEntity;
+                $this->resource = $resource;
                 $this->dimension = $dimension;
             }
 
@@ -131,9 +131,9 @@ class ContentNormalizerTest extends TestCase
                 throw new \RuntimeException('Should not be called while executing tests.');
             }
 
-            public function getContentRichEntity(): ContentRichEntityInterface
+            public function getResource(): ContentRichEntityInterface
             {
-                return $this->contentRichEntity;
+                return $this->resource;
             }
         };
 

--- a/Tests/Unit/Content/Application/ContentNormalizer/Normalizer/DimensionContentNormalizerTest.php
+++ b/Tests/Unit/Content/Application/ContentNormalizer/Normalizer/DimensionContentNormalizerTest.php
@@ -43,7 +43,7 @@ class DimensionContentNormalizerTest extends TestCase
         $object = $this->prophesize(DimensionContentInterface::class);
 
         $this->assertSame(
-            ['id', 'merged', 'dimension', 'contentRichEntity'],
+            ['id', 'merged', 'dimension', 'resource'],
             $normalizer->getIgnoredAttributes($object->reveal())
         );
     }
@@ -68,15 +68,15 @@ class DimensionContentNormalizerTest extends TestCase
     {
         $normalizer = $this->createDimensionContentNormalizerInstance();
 
-        $contentRichEntity = $this->prophesize(ContentRichEntityInterface::class);
-        $contentRichEntity->getId()->willReturn('content-id-123');
+        $resource = $this->prophesize(ContentRichEntityInterface::class);
+        $resource->getId()->willReturn('content-id-123');
 
         $dimension = $this->prophesize(DimensionInterface::class);
         $dimension->getLocale()->willReturn('en');
         $dimension->getStage()->willReturn('live');
 
         $object = $this->prophesize(DimensionContentInterface::class);
-        $object->getContentRichEntity()->willReturn($contentRichEntity->reveal());
+        $object->getResource()->willReturn($resource->reveal());
         $object->getDimension()->willReturn($dimension->reveal());
 
         $data = [

--- a/Tests/Unit/Content/Domain/Model/DimensionContentTraitTest.php
+++ b/Tests/Unit/Content/Domain/Model/DimensionContentTraitTest.php
@@ -37,7 +37,7 @@ class DimensionContentTraitTest extends TestCase
                 throw new \RuntimeException('Should not be called while executing tests.');
             }
 
-            public function getContentRichEntity(): ContentRichEntityInterface
+            public function getResource(): ContentRichEntityInterface
             {
                 throw new \RuntimeException('Should not be called while executing tests.');
             }

--- a/Tests/Unit/Content/Domain/Model/RoutableTraitTest.php
+++ b/Tests/Unit/Content/Domain/Model/RoutableTraitTest.php
@@ -40,11 +40,11 @@ class RoutableTraitTest extends TestCase
             /**
              * @var ContentRichEntityInterface
              */
-            private $contentRichEntity;
+            private $resource;
 
-            public function __construct(ContentRichEntityInterface $contentRichEntity, DimensionInterface $dimension)
+            public function __construct(ContentRichEntityInterface $resource, DimensionInterface $dimension)
             {
-                $this->contentRichEntity = $contentRichEntity;
+                $this->resource = $resource;
                 $this->dimension = $dimension;
             }
 
@@ -58,9 +58,9 @@ class RoutableTraitTest extends TestCase
                 return $this->dimension;
             }
 
-            public function getContentRichEntity(): ContentRichEntityInterface
+            public function getResource(): ContentRichEntityInterface
             {
-                return $this->contentRichEntity;
+                return $this->resource;
             }
         };
     }

--- a/Tests/Unit/Content/Infrastructure/Sulu/Admin/ContentViewBuilderFactoryTest.php
+++ b/Tests/Unit/Content/Infrastructure/Sulu/Admin/ContentViewBuilderFactoryTest.php
@@ -322,7 +322,7 @@ class ContentViewBuilderFactoryTest extends TestCase
                         return 'mock-resource-key';
                     }
 
-                    public function getContentRichEntity(): ContentRichEntityInterface
+                    public function getResource(): ContentRichEntityInterface
                     {
                         throw new \RuntimeException('Should not be called while executing tests.');
                     }
@@ -339,7 +339,7 @@ class ContentViewBuilderFactoryTest extends TestCase
                     use SeoTrait;
                     use ExcerptTrait;
 
-                    public function getContentRichEntity(): ContentRichEntityInterface
+                    public function getResource(): ContentRichEntityInterface
                     {
                         throw new \RuntimeException('Should not be called while executing tests.');
                     }
@@ -369,7 +369,7 @@ class ContentViewBuilderFactoryTest extends TestCase
                     use SeoTrait;
                     use ExcerptTrait;
 
-                    public function getContentRichEntity(): ContentRichEntityInterface
+                    public function getResource(): ContentRichEntityInterface
                     {
                         throw new \RuntimeException('Should not be called while executing tests.');
                     }

--- a/Tests/Unit/Content/Infrastructure/Sulu/Preview/ContentObjectProviderTest.php
+++ b/Tests/Unit/Content/Infrastructure/Sulu/Preview/ContentObjectProviderTest.php
@@ -163,7 +163,7 @@ class ContentObjectProviderTest extends TestCase
         $contentRichEntity->getId()->willReturn($id);
 
         $dimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent->getContentRichEntity()->willReturn($contentRichEntity->reveal());
+        $dimensionContent->getResource()->willReturn($contentRichEntity->reveal());
 
         $actualId = (string) $this->contentObjectProvider->getId($dimensionContent->reveal());
 
@@ -224,7 +224,7 @@ class ContentObjectProviderTest extends TestCase
         $dimension->getLocale()->willReturn('en');
 
         $dimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent->getContentRichEntity()->willReturn($contentRichEntity->reveal());
+        $dimensionContent->getResource()->willReturn($contentRichEntity->reveal());
         $dimensionContent->getDimension()->willReturn($dimension->reveal());
 
         $serializedObject = json_encode([

--- a/Tests/Unit/Content/Infrastructure/Sulu/SmartContent/DataItem/ContentDataItemTest.php
+++ b/Tests/Unit/Content/Infrastructure/Sulu/SmartContent/DataItem/ContentDataItemTest.php
@@ -34,11 +34,11 @@ class ContentDataItemTest extends TestCase
 
     public function testGetId(): void
     {
-        $contentRichEntity = $this->prophesize(ContentRichEntityInterface::class);
-        $contentRichEntity->getId()->willReturn('123-123');
+        $resource = $this->prophesize(ContentRichEntityInterface::class);
+        $resource->getId()->willReturn('123-123');
 
         $dimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent->getContentRichEntity()->willReturn($contentRichEntity->reveal());
+        $dimensionContent->getResource()->willReturn($resource->reveal());
 
         $dataItem = $this->getContentDataItem($dimensionContent->reveal(), []);
 
@@ -47,11 +47,11 @@ class ContentDataItemTest extends TestCase
 
     public function testGetTitle(): void
     {
-        $contentRichEntity = $this->prophesize(ContentRichEntityInterface::class);
-        $contentRichEntity->getId()->willReturn('123-123');
+        $resource = $this->prophesize(ContentRichEntityInterface::class);
+        $resource->getId()->willReturn('123-123');
 
         $dimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent->getContentRichEntity()->willReturn($contentRichEntity->reveal());
+        $dimensionContent->getResource()->willReturn($resource->reveal());
 
         $data = [
             'title' => 'test-title-1',
@@ -65,11 +65,11 @@ class ContentDataItemTest extends TestCase
 
     public function testGetNameAsTitle(): void
     {
-        $contentRichEntity = $this->prophesize(ContentRichEntityInterface::class);
-        $contentRichEntity->getId()->willReturn('123-123');
+        $resource = $this->prophesize(ContentRichEntityInterface::class);
+        $resource->getId()->willReturn('123-123');
 
         $dimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent->getContentRichEntity()->willReturn($contentRichEntity->reveal());
+        $dimensionContent->getResource()->willReturn($resource->reveal());
 
         $data = [
             'title' => null,
@@ -83,11 +83,11 @@ class ContentDataItemTest extends TestCase
 
     public function testGetImage(): void
     {
-        $contentRichEntity = $this->prophesize(ContentRichEntityInterface::class);
-        $contentRichEntity->getId()->willReturn('123-123');
+        $resource = $this->prophesize(ContentRichEntityInterface::class);
+        $resource->getId()->willReturn('123-123');
 
         $dimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent->getContentRichEntity()->willReturn($contentRichEntity->reveal());
+        $dimensionContent->getResource()->willReturn($resource->reveal());
 
         $dataItem = $this->getContentDataItem($dimensionContent->reveal(), []);
 
@@ -96,8 +96,8 @@ class ContentDataItemTest extends TestCase
 
     public function testGetPublished(): void
     {
-        $contentRichEntity = $this->prophesize(ContentRichEntityInterface::class);
-        $contentRichEntity->getId()->willReturn('123-123');
+        $resource = $this->prophesize(ContentRichEntityInterface::class);
+        $resource->getId()->willReturn('123-123');
 
         $dimension = $this->prophesize(DimensionInterface::class);
         $dimension->getLocale()->willReturn('en');
@@ -106,7 +106,7 @@ class ContentDataItemTest extends TestCase
 
         $dimensionContent = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent->willImplement(WorkflowInterface::class);
-        $dimensionContent->getContentRichEntity()->willReturn($contentRichEntity->reveal());
+        $dimensionContent->getResource()->willReturn($resource->reveal());
         $dimensionContent->getDimension()->willReturn($dimension->reveal());
         $dimensionContent->getWorkflowPublished()->willReturn($published);
 
@@ -117,14 +117,14 @@ class ContentDataItemTest extends TestCase
 
     public function testGetPublishedLocaleNull(): void
     {
-        $contentRichEntity = $this->prophesize(ContentRichEntityInterface::class);
-        $contentRichEntity->getId()->willReturn('123-123');
+        $resource = $this->prophesize(ContentRichEntityInterface::class);
+        $resource->getId()->willReturn('123-123');
 
         $dimension = $this->prophesize(DimensionInterface::class);
         $dimension->getLocale()->willReturn(null);
 
         $dimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent->getContentRichEntity()->willReturn($contentRichEntity->reveal());
+        $dimensionContent->getResource()->willReturn($resource->reveal());
         $dimensionContent->getDimension()->willReturn($dimension->reveal());
 
         $dataItem = $this->getContentDataItem($dimensionContent->reveal(), []);
@@ -134,14 +134,14 @@ class ContentDataItemTest extends TestCase
 
     public function testGetPublishedNoWorkflow(): void
     {
-        $contentRichEntity = $this->prophesize(ContentRichEntityInterface::class);
-        $contentRichEntity->getId()->willReturn('123-123');
+        $resource = $this->prophesize(ContentRichEntityInterface::class);
+        $resource->getId()->willReturn('123-123');
 
         $dimension = $this->prophesize(DimensionInterface::class);
         $dimension->getLocale()->willReturn('en');
 
         $dimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent->getContentRichEntity()->willReturn($contentRichEntity->reveal());
+        $dimensionContent->getResource()->willReturn($resource->reveal());
         $dimensionContent->getDimension()->willReturn($dimension->reveal());
 
         $dataItem = $this->getContentDataItem($dimensionContent->reveal(), []);
@@ -151,8 +151,8 @@ class ContentDataItemTest extends TestCase
 
     public function testGetPublishedState(): void
     {
-        $contentRichEntity = $this->prophesize(ContentRichEntityInterface::class);
-        $contentRichEntity->getId()->willReturn('123-123');
+        $resource = $this->prophesize(ContentRichEntityInterface::class);
+        $resource->getId()->willReturn('123-123');
 
         $dimension = $this->prophesize(DimensionInterface::class);
         $dimension->getLocale()->willReturn('en');
@@ -160,7 +160,7 @@ class ContentDataItemTest extends TestCase
 
         $dimensionContent = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent->willImplement(WorkflowInterface::class);
-        $dimensionContent->getContentRichEntity()->willReturn($contentRichEntity->reveal());
+        $dimensionContent->getResource()->willReturn($resource->reveal());
         $dimensionContent->getDimension()->willReturn($dimension->reveal());
         $dimensionContent->getWorkflowPlace()->willReturn(WorkflowInterface::WORKFLOW_PLACE_PUBLISHED);
 
@@ -171,14 +171,14 @@ class ContentDataItemTest extends TestCase
 
     public function testGetPublishedStateLocaleNull(): void
     {
-        $contentRichEntity = $this->prophesize(ContentRichEntityInterface::class);
-        $contentRichEntity->getId()->willReturn('123-123');
+        $resource = $this->prophesize(ContentRichEntityInterface::class);
+        $resource->getId()->willReturn('123-123');
 
         $dimension = $this->prophesize(DimensionInterface::class);
         $dimension->getLocale()->willReturn(null);
 
         $dimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent->getContentRichEntity()->willReturn($contentRichEntity->reveal());
+        $dimensionContent->getResource()->willReturn($resource->reveal());
         $dimensionContent->getDimension()->willReturn($dimension->reveal());
 
         $dataItem = $this->getContentDataItem($dimensionContent->reveal(), []);
@@ -188,15 +188,15 @@ class ContentDataItemTest extends TestCase
 
     public function testGetPublishedStateStageLive(): void
     {
-        $contentRichEntity = $this->prophesize(ContentRichEntityInterface::class);
-        $contentRichEntity->getId()->willReturn('123-123');
+        $resource = $this->prophesize(ContentRichEntityInterface::class);
+        $resource->getId()->willReturn('123-123');
 
         $dimension = $this->prophesize(DimensionInterface::class);
         $dimension->getLocale()->willReturn('en');
         $dimension->getStage()->willReturn(DimensionInterface::STAGE_LIVE);
 
         $dimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent->getContentRichEntity()->willReturn($contentRichEntity->reveal());
+        $dimensionContent->getResource()->willReturn($resource->reveal());
         $dimensionContent->getDimension()->willReturn($dimension->reveal());
 
         $dataItem = $this->getContentDataItem($dimensionContent->reveal(), []);
@@ -206,15 +206,15 @@ class ContentDataItemTest extends TestCase
 
     public function testGetPublishedStateNoWorkflow(): void
     {
-        $contentRichEntity = $this->prophesize(ContentRichEntityInterface::class);
-        $contentRichEntity->getId()->willReturn('123-123');
+        $resource = $this->prophesize(ContentRichEntityInterface::class);
+        $resource->getId()->willReturn('123-123');
 
         $dimension = $this->prophesize(DimensionInterface::class);
         $dimension->getLocale()->willReturn('en');
         $dimension->getStage()->willReturn(DimensionInterface::STAGE_DRAFT);
 
         $dimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent->getContentRichEntity()->willReturn($contentRichEntity->reveal());
+        $dimensionContent->getResource()->willReturn($resource->reveal());
         $dimensionContent->getDimension()->willReturn($dimension->reveal());
 
         $dataItem = $this->getContentDataItem($dimensionContent->reveal(), []);
@@ -224,8 +224,8 @@ class ContentDataItemTest extends TestCase
 
     public function testGetPublishedStateUnpublished(): void
     {
-        $contentRichEntity = $this->prophesize(ContentRichEntityInterface::class);
-        $contentRichEntity->getId()->willReturn('123-123');
+        $resource = $this->prophesize(ContentRichEntityInterface::class);
+        $resource->getId()->willReturn('123-123');
 
         $dimension = $this->prophesize(DimensionInterface::class);
         $dimension->getLocale()->willReturn('en');
@@ -233,7 +233,7 @@ class ContentDataItemTest extends TestCase
 
         $dimensionContent = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent->willImplement(WorkflowInterface::class);
-        $dimensionContent->getContentRichEntity()->willReturn($contentRichEntity->reveal());
+        $dimensionContent->getResource()->willReturn($resource->reveal());
         $dimensionContent->getDimension()->willReturn($dimension->reveal());
         $dimensionContent->getWorkflowPlace()->willReturn(WorkflowInterface::WORKFLOW_PLACE_UNPUBLISHED);
 
@@ -244,8 +244,8 @@ class ContentDataItemTest extends TestCase
 
     public function testGetPublishedStateDraft(): void
     {
-        $contentRichEntity = $this->prophesize(ContentRichEntityInterface::class);
-        $contentRichEntity->getId()->willReturn('123-123');
+        $resource = $this->prophesize(ContentRichEntityInterface::class);
+        $resource->getId()->willReturn('123-123');
 
         $dimension = $this->prophesize(DimensionInterface::class);
         $dimension->getLocale()->willReturn('en');
@@ -253,7 +253,7 @@ class ContentDataItemTest extends TestCase
 
         $dimensionContent = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent->willImplement(WorkflowInterface::class);
-        $dimensionContent->getContentRichEntity()->willReturn($contentRichEntity->reveal());
+        $dimensionContent->getResource()->willReturn($resource->reveal());
         $dimensionContent->getDimension()->willReturn($dimension->reveal());
         $dimensionContent->getWorkflowPlace()->willReturn(WorkflowInterface::WORKFLOW_PLACE_DRAFT);
 

--- a/Tests/Unit/Mocks/DimensionContentMockWrapperTrait.php
+++ b/Tests/Unit/Mocks/DimensionContentMockWrapperTrait.php
@@ -33,9 +33,9 @@ trait DimensionContentMockWrapperTrait
         return $this->instance->getDimension();
     }
 
-    public function getContentRichEntity(): ContentRichEntityInterface
+    public function getResource(): ContentRichEntityInterface
     {
-        return $this->instance->getContentRichEntity();
+        return $this->instance->getResource();
     }
 
     public function isMerged(): bool

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,12 @@
 
 ## dev-master
 
+### Rename getContentRichEntity method of DimensionContentInterface to getResource
+
+The `getContentRichEntity` method of the `DimensionContentInterface` was renamed to `getResource`. 
+This makes the naming consistent with the `getResourceKey` method of the `DimensionContentInterface` and 
+the `getResourceId` method of the `RoutableInterface`.
+
 ### Rename getRoutableId method of RoutableInterface to getResourceId
 
 The `getRoutableId` method of the `RoutableInterface` was renamed to `getResourceId`. This makes the naming consistent 


### PR DESCRIPTION
This makes the naming consistent with the `getResourceKey` method of the `DimensionContentInterface` and 
the `getResourceId` method of the `RoutableInterface`.