### PR TITLE
Pass DimensionContentCollection to DataMapper services

### DIFF
--- a/Content/Application/ContentDataMapper/ContentDataMapper.php
+++ b/Content/Application/ContentDataMapper/ContentDataMapper.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper;
 
 use Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMapper\DataMapperInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
 
 class ContentDataMapper implements ContentDataMapperInterface
 {
@@ -32,11 +33,10 @@ class ContentDataMapper implements ContentDataMapperInterface
 
     public function map(
         array $data,
-        object $unlocalizedObject,
-        ?object $localizedObject = null
+        DimensionContentCollectionInterface $dimensionContentCollection
     ): void {
         foreach ($this->dataMappers as $mapper) {
-            $mapper->map($data, $unlocalizedObject, $localizedObject);
+            $mapper->map($data, $dimensionContentCollection);
         }
     }
 }

--- a/Content/Application/ContentDataMapper/ContentDataMapperInterface.php
+++ b/Content/Application/ContentDataMapper/ContentDataMapperInterface.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper;
 
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
+
 interface ContentDataMapperInterface
 {
     /**
@@ -20,7 +22,6 @@ interface ContentDataMapperInterface
      */
     public function map(
         array $data,
-        object $unlocalizedObject,
-        ?object $localizedObject = null
+        DimensionContentCollectionInterface $dimensionContentCollection
     ): void;
 }

--- a/Content/Application/ContentDataMapper/DataMapper/DataMapperInterface.php
+++ b/Content/Application/ContentDataMapper/DataMapper/DataMapperInterface.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMapper;
 
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
+
 interface DataMapperInterface
 {
     /**
@@ -20,7 +22,6 @@ interface DataMapperInterface
      */
     public function map(
         array $data,
-        object $unlocalizedObject,
-        ?object $localizedObject = null
+        DimensionContentCollectionInterface $dimensionContentCollection
     ): void;
 }

--- a/Content/Application/ContentDataMapper/DataMapper/ExcerptDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/ExcerptDataMapper.php
@@ -15,6 +15,7 @@ namespace Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMa
 
 use Sulu\Bundle\ContentBundle\Content\Domain\Factory\CategoryFactoryInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Factory\TagFactoryInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ExcerptInterface;
 
 class ExcerptDataMapper implements DataMapperInterface
@@ -37,9 +38,14 @@ class ExcerptDataMapper implements DataMapperInterface
 
     public function map(
         array $data,
-        object $unlocalizedObject,
-        ?object $localizedObject = null
+        DimensionContentCollectionInterface $dimensionContentCollection
     ): void {
+        $dimensionAttributes = $dimensionContentCollection->getDimensionAttributes();
+        $localizedObject = $dimensionContentCollection->getDimensionContent($dimensionAttributes);
+
+        $unlocalizedDimensionAttributes = array_merge($dimensionAttributes, ['locale' => null]);
+        $unlocalizedObject = $dimensionContentCollection->getDimensionContent($unlocalizedDimensionAttributes);
+
         if (!$unlocalizedObject instanceof ExcerptInterface) {
             return;
         }

--- a/Content/Application/ContentDataMapper/DataMapper/ExcerptDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/ExcerptDataMapper.php
@@ -41,14 +41,14 @@ class ExcerptDataMapper implements DataMapperInterface
         DimensionContentCollectionInterface $dimensionContentCollection
     ): void {
         $dimensionAttributes = $dimensionContentCollection->getDimensionAttributes();
-        $localizedObject = $dimensionContentCollection->getDimensionContent($dimensionAttributes);
-
         $unlocalizedDimensionAttributes = array_merge($dimensionAttributes, ['locale' => null]);
         $unlocalizedObject = $dimensionContentCollection->getDimensionContent($unlocalizedDimensionAttributes);
 
         if (!$unlocalizedObject instanceof ExcerptInterface) {
             return;
         }
+
+        $localizedObject = $dimensionContentCollection->getDimensionContent($dimensionAttributes);
 
         if ($localizedObject) {
             if (!$localizedObject instanceof ExcerptInterface) {

--- a/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapper.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMapper;
 
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\RoutableInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\TemplateInterface;
 use Sulu\Bundle\RouteBundle\Generator\RouteGeneratorInterface;
@@ -76,9 +77,14 @@ class RoutableDataMapper implements DataMapperInterface
 
     public function map(
         array $data,
-        object $unlocalizedObject,
-        ?object $localizedObject = null
+        DimensionContentCollectionInterface $dimensionContentCollection
     ): void {
+        $dimensionAttributes = $dimensionContentCollection->getDimensionAttributes();
+        $localizedObject = $dimensionContentCollection->getDimensionContent($dimensionAttributes);
+
+        $unlocalizedDimensionAttributes = array_merge($dimensionAttributes, ['locale' => null]);
+        $unlocalizedObject = $dimensionContentCollection->getDimensionContent($unlocalizedDimensionAttributes);
+
         if (!$localizedObject || !$localizedObject instanceof RoutableInterface) {
             return;
         }

--- a/Content/Application/ContentDataMapper/DataMapper/SeoDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/SeoDataMapper.php
@@ -13,15 +13,21 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMapper;
 
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\SeoInterface;
 
 class SeoDataMapper implements DataMapperInterface
 {
     public function map(
         array $data,
-        object $unlocalizedObject,
-        ?object $localizedObject = null
+        DimensionContentCollectionInterface $dimensionContentCollection
     ): void {
+        $dimensionAttributes = $dimensionContentCollection->getDimensionAttributes();
+        $localizedObject = $dimensionContentCollection->getDimensionContent($dimensionAttributes);
+
+        $unlocalizedDimensionAttributes = array_merge($dimensionAttributes, ['locale' => null]);
+        $unlocalizedObject = $dimensionContentCollection->getDimensionContent($unlocalizedDimensionAttributes);
+
         if (!$unlocalizedObject instanceof SeoInterface) {
             return;
         }

--- a/Content/Application/ContentDataMapper/DataMapper/SeoDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/SeoDataMapper.php
@@ -23,14 +23,14 @@ class SeoDataMapper implements DataMapperInterface
         DimensionContentCollectionInterface $dimensionContentCollection
     ): void {
         $dimensionAttributes = $dimensionContentCollection->getDimensionAttributes();
-        $localizedObject = $dimensionContentCollection->getDimensionContent($dimensionAttributes);
-
         $unlocalizedDimensionAttributes = array_merge($dimensionAttributes, ['locale' => null]);
         $unlocalizedObject = $dimensionContentCollection->getDimensionContent($unlocalizedDimensionAttributes);
 
         if (!$unlocalizedObject instanceof SeoInterface) {
             return;
         }
+
+        $localizedObject = $dimensionContentCollection->getDimensionContent($dimensionAttributes);
 
         if ($localizedObject) {
             if (!$localizedObject instanceof SeoInterface) {

--- a/Content/Application/ContentDataMapper/DataMapper/TemplateDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/TemplateDataMapper.php
@@ -43,8 +43,6 @@ class TemplateDataMapper implements DataMapperInterface
         DimensionContentCollectionInterface $dimensionContentCollection
     ): void {
         $dimensionAttributes = $dimensionContentCollection->getDimensionAttributes();
-        $localizedObject = $dimensionContentCollection->getDimensionContent($dimensionAttributes);
-
         $unlocalizedDimensionAttributes = array_merge($dimensionAttributes, ['locale' => null]);
         $unlocalizedObject = $dimensionContentCollection->getDimensionContent($unlocalizedDimensionAttributes);
 
@@ -70,6 +68,8 @@ class TemplateDataMapper implements DataMapperInterface
             $type,
             $template
         );
+
+        $localizedObject = $dimensionContentCollection->getDimensionContent($dimensionAttributes);
 
         if ($localizedObject) {
             if (!$localizedObject instanceof TemplateInterface) {

--- a/Content/Application/ContentDataMapper/DataMapper/TemplateDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/TemplateDataMapper.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMapper;
 
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\TemplateInterface;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
 
@@ -39,9 +40,14 @@ class TemplateDataMapper implements DataMapperInterface
 
     public function map(
         array $data,
-        object $unlocalizedObject,
-        ?object $localizedObject = null
+        DimensionContentCollectionInterface $dimensionContentCollection
     ): void {
+        $dimensionAttributes = $dimensionContentCollection->getDimensionAttributes();
+        $localizedObject = $dimensionContentCollection->getDimensionContent($dimensionAttributes);
+
+        $unlocalizedDimensionAttributes = array_merge($dimensionAttributes, ['locale' => null]);
+        $unlocalizedObject = $dimensionContentCollection->getDimensionContent($unlocalizedDimensionAttributes);
+
         if (!$unlocalizedObject instanceof TemplateInterface) {
             return;
         }

--- a/Content/Application/ContentDataMapper/DataMapper/WorkflowDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/WorkflowDataMapper.php
@@ -24,14 +24,14 @@ class WorkflowDataMapper implements DataMapperInterface
         DimensionContentCollectionInterface $dimensionContentCollection
     ): void {
         $dimensionAttributes = $dimensionContentCollection->getDimensionAttributes();
-        $localizedObject = $dimensionContentCollection->getDimensionContent($dimensionAttributes);
-
         $unlocalizedDimensionAttributes = array_merge($dimensionAttributes, ['locale' => null]);
         $unlocalizedObject = $dimensionContentCollection->getDimensionContent($unlocalizedDimensionAttributes);
 
         if (!$unlocalizedObject instanceof WorkflowInterface) {
             return;
         }
+
+        $localizedObject = $dimensionContentCollection->getDimensionContent($dimensionAttributes);
 
         if ($localizedObject) {
             if (!$localizedObject instanceof WorkflowInterface) {

--- a/Content/Application/ContentDataMapper/DataMapper/WorkflowDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/WorkflowDataMapper.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMapper;
 
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\WorkflowInterface;
 
@@ -20,9 +21,14 @@ class WorkflowDataMapper implements DataMapperInterface
 {
     public function map(
         array $data,
-        object $unlocalizedObject,
-        ?object $localizedObject = null
+        DimensionContentCollectionInterface $dimensionContentCollection
     ): void {
+        $dimensionAttributes = $dimensionContentCollection->getDimensionAttributes();
+        $localizedObject = $dimensionContentCollection->getDimensionContent($dimensionAttributes);
+
+        $unlocalizedDimensionAttributes = array_merge($dimensionAttributes, ['locale' => null]);
+        $unlocalizedObject = $dimensionContentCollection->getDimensionContent($unlocalizedDimensionAttributes);
+
         if (!$unlocalizedObject instanceof WorkflowInterface) {
             return;
         }

--- a/Content/Application/ContentMerger/ContentMerger.php
+++ b/Content/Application/ContentMerger/ContentMerger.php
@@ -43,18 +43,19 @@ class ContentMerger implements ContentMergerInterface
 
     public function merge(DimensionContentCollectionInterface $dimensionContentCollection): DimensionContentInterface
     {
-        $unlocalizedDimensionContent = $dimensionContentCollection->getUnlocalizedDimensionContent();
-
-        if (!$unlocalizedDimensionContent) {
+        if (!$dimensionContentCollection->count()) {
             throw new \RuntimeException('Expected at least one dimensionContent given.');
         }
 
-        $contentRichEntity = $unlocalizedDimensionContent->getResource();
-
-        $mergedDimensionContent = $contentRichEntity->createDimensionContent();
-        $mergedDimensionContent->markAsMerged();
+        $mergedDimensionContent = null;
 
         foreach ($dimensionContentCollection as $dimensionContent) {
+            if (!$mergedDimensionContent) {
+                $contentRichEntity = $dimensionContent->getResource();
+                $mergedDimensionContent = $contentRichEntity->createDimensionContent();
+                $mergedDimensionContent->markAsMerged();
+            }
+
             foreach ($this->mergers as $merger) {
                 $merger->merge($mergedDimensionContent, $dimensionContent);
             }

--- a/Content/Application/ContentWorkflow/ContentWorkflow.php
+++ b/Content/Application/ContentWorkflow/ContentWorkflow.php
@@ -86,9 +86,7 @@ class ContentWorkflow implements ContentWorkflowInterface
          */
 
         $dimensionContentCollection = $this->dimensionContentRepository->load($contentRichEntity, $dimensionAttributes);
-        $dimensionAttributes = $dimensionContentCollection->getDimensionAttributes();
-
-        $localizedDimensionContent = $dimensionContentCollection->getLocalizedDimensionContent();
+        $localizedDimensionContent = $dimensionContentCollection->getDimensionContent($dimensionAttributes);
 
         if (!$localizedDimensionContent) {
             throw new ContentNotFoundException($contentRichEntity, $dimensionAttributes);

--- a/Content/Application/ContentWorkflow/ContentWorkflow.php
+++ b/Content/Application/ContentWorkflow/ContentWorkflow.php
@@ -86,6 +86,7 @@ class ContentWorkflow implements ContentWorkflowInterface
          */
 
         $dimensionContentCollection = $this->dimensionContentRepository->load($contentRichEntity, $dimensionAttributes);
+        $dimensionAttributes = $dimensionContentCollection->getDimensionAttributes();
         $localizedDimensionContent = $dimensionContentCollection->getDimensionContent($dimensionAttributes);
 
         if (!$localizedDimensionContent) {

--- a/Content/Application/ContentWorkflow/Subscriber/UnpublishTransitionSubscriber.php
+++ b/Content/Application/ContentWorkflow/Subscriber/UnpublishTransitionSubscriber.php
@@ -70,13 +70,13 @@ class UnpublishTransitionSubscriber implements EventSubscriberInterface
         $liveDimensionAttributes = array_merge($dimensionAttributes, ['stage' => DimensionContentInterface::STAGE_LIVE]);
 
         $dimensionContentCollection = $this->dimensionContentRepository->load($contentRichEntity, $liveDimensionAttributes);
-        $localizedDimensionContent = $dimensionContentCollection->getDimensionContent($liveDimensionAttributes);
+        $localizedLiveDimensionContent = $dimensionContentCollection->getDimensionContent($liveDimensionAttributes);
 
-        if (!$localizedDimensionContent) {
+        if (!$localizedLiveDimensionContent) {
             throw new ContentNotFoundException($contentRichEntity, $liveDimensionAttributes);
         }
 
-        $this->entityManager->remove($localizedDimensionContent);
+        $this->entityManager->remove($localizedLiveDimensionContent);
     }
 
     public static function getSubscribedEvents(): array

--- a/Content/Application/ContentWorkflow/Subscriber/UnpublishTransitionSubscriber.php
+++ b/Content/Application/ContentWorkflow/Subscriber/UnpublishTransitionSubscriber.php
@@ -70,7 +70,8 @@ class UnpublishTransitionSubscriber implements EventSubscriberInterface
         $liveDimensionAttributes = array_merge($dimensionAttributes, ['stage' => DimensionContentInterface::STAGE_LIVE]);
 
         $dimensionContentCollection = $this->dimensionContentRepository->load($contentRichEntity, $liveDimensionAttributes);
-        $localizedDimensionContent = $dimensionContentCollection->getLocalizedDimensionContent();
+        $localizedDimensionContent = $dimensionContentCollection->getDimensionContent($liveDimensionAttributes);
+
         if (!$localizedDimensionContent) {
             throw new ContentNotFoundException($contentRichEntity, $liveDimensionAttributes);
         }

--- a/Content/Application/DimensionContentCollectionFactory/DimensionContentCollectionFactory.php
+++ b/Content/Application/DimensionContentCollectionFactory/DimensionContentCollectionFactory.php
@@ -93,13 +93,15 @@ class DimensionContentCollectionFactory implements DimensionContentCollectionFac
             }
         }
 
-        $this->contentDataMapper->map($data, $unlocalizedDimensionContent, $localizedDimensionContent);
-
-        return new DimensionContentCollection(
+        $dimensionContentCollection = new DimensionContentCollection(
             $orderedContentDimensions,
             $dimensionAttributes,
             $dimensionContentCollection->getDimensionContentClass()
         );
+
+        $this->contentDataMapper->map($data, $dimensionContentCollection);
+
+        return $dimensionContentCollection;
     }
 
     /**

--- a/Content/Domain/Model/DimensionContentCollection.php
+++ b/Content/Domain/Model/DimensionContentCollection.php
@@ -87,11 +87,6 @@ class DimensionContentCollection implements \IteratorAggregate, DimensionContent
         return $this->dimensionContentClass;
     }
 
-    public function getLocalizedDimensionContent(): ?DimensionContentInterface
-    {
-        return $this->localizedDimensionContent;
-    }
-
     public function getDimensionContent(array $dimensionAttributes): ?DimensionContentInterface
     {
         $dimensionAttributes = array_merge($this->defaultDimensionAttributes, $dimensionAttributes);

--- a/Content/Domain/Model/DimensionContentCollection.php
+++ b/Content/Domain/Model/DimensionContentCollection.php
@@ -87,11 +87,6 @@ class DimensionContentCollection implements \IteratorAggregate, DimensionContent
         return $this->dimensionContentClass;
     }
 
-    public function getUnlocalizedDimensionContent(): ?DimensionContentInterface
-    {
-        return $this->unlocalizedDimensionContent;
-    }
-
     public function getLocalizedDimensionContent(): ?DimensionContentInterface
     {
         return $this->localizedDimensionContent;

--- a/Content/Domain/Model/DimensionContentCollectionInterface.php
+++ b/Content/Domain/Model/DimensionContentCollectionInterface.php
@@ -18,8 +18,6 @@ namespace Sulu\Bundle\ContentBundle\Content\Domain\Model;
  */
 interface DimensionContentCollectionInterface extends \Traversable, \Countable
 {
-    public function getUnlocalizedDimensionContent(): ?DimensionContentInterface;
-
     public function getLocalizedDimensionContent(): ?DimensionContentInterface;
 
     /**

--- a/Content/Domain/Model/DimensionContentCollectionInterface.php
+++ b/Content/Domain/Model/DimensionContentCollectionInterface.php
@@ -18,8 +18,6 @@ namespace Sulu\Bundle\ContentBundle\Content\Domain\Model;
  */
 interface DimensionContentCollectionInterface extends \Traversable, \Countable
 {
-    public function getLocalizedDimensionContent(): ?DimensionContentInterface;
-
     /**
      * @param mixed[] $dimensionAttributes
      */

--- a/Content/Infrastructure/Sulu/Preview/ContentObjectProvider.php
+++ b/Content/Infrastructure/Sulu/Preview/ContentObjectProvider.php
@@ -101,7 +101,8 @@ class ContentObjectProvider implements PreviewObjectProviderInterface
      */
     public function setValues($object, $locale, array $data): void
     {
-        $this->contentDataMapper->map($data, $object, $object);
+        $previewDimensionContentCollection = new PreviewDimensionContentCollection($object, $locale);
+        $this->contentDataMapper->map($data, $previewDimensionContentCollection);
     }
 
     /**

--- a/Content/Infrastructure/Sulu/Preview/PreviewDimensionContentCollection.php
+++ b/Content/Infrastructure/Sulu/Preview/PreviewDimensionContentCollection.php
@@ -45,11 +45,6 @@ class PreviewDimensionContentCollection implements \IteratorAggregate, Dimension
         return \get_class($this->previewDimensionContent);
     }
 
-    public function getUnlocalizedDimensionContent(): ?DimensionContentInterface
-    {
-        return $this->previewDimensionContent;
-    }
-
     public function getLocalizedDimensionContent(): ?DimensionContentInterface
     {
         return $this->previewDimensionContent;

--- a/Content/Infrastructure/Sulu/Preview/PreviewDimensionContentCollection.php
+++ b/Content/Infrastructure/Sulu/Preview/PreviewDimensionContentCollection.php
@@ -45,11 +45,6 @@ class PreviewDimensionContentCollection implements \IteratorAggregate, Dimension
         return \get_class($this->previewDimensionContent);
     }
 
-    public function getLocalizedDimensionContent(): ?DimensionContentInterface
-    {
-        return $this->previewDimensionContent;
-    }
-
     public function getDimensionContent(array $dimensionAttributes): ?DimensionContentInterface
     {
         return $this->previewDimensionContent;

--- a/Content/Infrastructure/Sulu/Preview/PreviewDimensionContentCollection.php
+++ b/Content/Infrastructure/Sulu/Preview/PreviewDimensionContentCollection.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Preview;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
+
+/**
+ * @implements \IteratorAggregate<DimensionContentInterface>
+ */
+class PreviewDimensionContentCollection implements \IteratorAggregate, DimensionContentCollectionInterface
+{
+    /**
+     * @var DimensionContentInterface
+     */
+    private $previewDimensionContent;
+
+    /**
+     * @var string
+     */
+    private $previewLocale;
+
+    public function __construct(
+        DimensionContentInterface $previewDimensionContent,
+        string $previewLocale
+    ) {
+        $this->previewDimensionContent = $previewDimensionContent;
+        $this->previewLocale = $previewLocale;
+    }
+
+    public function getDimensionContentClass(): string
+    {
+        return \get_class($this->previewDimensionContent);
+    }
+
+    public function getUnlocalizedDimensionContent(): ?DimensionContentInterface
+    {
+        return $this->previewDimensionContent;
+    }
+
+    public function getLocalizedDimensionContent(): ?DimensionContentInterface
+    {
+        return $this->previewDimensionContent;
+    }
+
+    public function getDimensionContent(array $dimensionAttributes): ?DimensionContentInterface
+    {
+        return $this->previewDimensionContent;
+    }
+
+    public function getDimensionAttributes(): array
+    {
+        return ['locale' => $this->previewLocale];
+    }
+
+    public function getIterator()
+    {
+        return new ArrayCollection([$this->previewDimensionContent]);
+    }
+
+    public function count(): int
+    {
+        return 1;
+    }
+}

--- a/Content/Infrastructure/Sulu/Preview/PreviewDimensionContentCollection.php
+++ b/Content/Infrastructure/Sulu/Preview/PreviewDimensionContentCollection.php
@@ -18,6 +18,7 @@ use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInt
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 
 /**
+ * @internal
  * @implements \IteratorAggregate<DimensionContentInterface>
  */
 class PreviewDimensionContentCollection implements \IteratorAggregate, DimensionContentCollectionInterface
@@ -52,7 +53,10 @@ class PreviewDimensionContentCollection implements \IteratorAggregate, Dimension
 
     public function getDimensionAttributes(): array
     {
-        return ['locale' => $this->previewLocale];
+        return array_merge(
+            $this->previewDimensionContent::getDefaultDimensionAttributes(),
+            ['locale' => $this->previewLocale]
+        );
     }
 
     public function getIterator()

--- a/Content/Infrastructure/Sulu/SmartContent/Provider/ContentDataProvider.php
+++ b/Content/Infrastructure/Sulu/SmartContent/Provider/ContentDataProvider.php
@@ -93,7 +93,7 @@ class ContentDataProvider extends BaseDataProvider
      * @param DimensionContentInterface[] $data
      * @param string $locale
      *
-     * @return ArrayAccessItem[]
+     * @return ResourceItemInterface[]
      */
     protected function decorateResourceItems(array $data, $locale): array
     {

--- a/Tests/Application/config/bootstrap.php
+++ b/Tests/Application/config/bootstrap.php
@@ -36,4 +36,4 @@ if (is_array($env = @include dirname(__DIR__) . '/.env.local.php')) {
 
 $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';
 $_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
-$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';
+$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], \FILTER_VALIDATE_BOOLEAN) ? '1' : '0';

--- a/Tests/Functional/Content/Infrastructure/Sulu/Sitemap/ContentSitemapProviderTest.php
+++ b/Tests/Functional/Content/Infrastructure/Sulu/Sitemap/ContentSitemapProviderTest.php
@@ -24,11 +24,10 @@ use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapUrl;
 class ContentSitemapProviderTest extends SuluTestCase
 {
     use AssertSnapshotTrait;
+    use CreateExampleTrait;
 
     const SCHEME = 'https';
     const HOST = 'localhost';
-
-    use CreateExampleTrait;
 
     /**
      * @var ContentSitemapProvider

--- a/Tests/Traits/CreateExampleTrait.php
+++ b/Tests/Traits/CreateExampleTrait.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\ContentDataMapper;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\ContentDataMapperInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollection;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\WorkflowInterface;
 use Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\Example;
@@ -91,7 +92,12 @@ trait CreateExampleTrait
             $entityManager->persist($draftLocalizedDimension);
 
             // Map Draft Data
-            $contentDataMapper->map($fillWithdefaultData($draftData), $draftUnlocalizedDimension, $draftLocalizedDimension);
+            $draftDimensionContentCollection = new DimensionContentCollection(
+                [$draftUnlocalizedDimension, $draftLocalizedDimension],
+                ['stage' => DimensionContentInterface::STAGE_DRAFT, 'locale' => $locale],
+                ExampleDimensionContent::class
+            );
+            $contentDataMapper->map($fillWithdefaultData($draftData), $draftDimensionContentCollection);
             $draftLocalizedDimension->setWorkflowPlace(WorkflowInterface::WORKFLOW_PLACE_DRAFT);
 
             if ($liveData) {
@@ -122,8 +128,13 @@ trait CreateExampleTrait
                 $liveLocalizedDimension->setWorkflowPublished(new \DateTimeImmutable());
 
                 // map data
+                $liveDimensionContentCollection = new DimensionContentCollection(
+                    [$liveUnlocalizedDimension, $liveLocalizedDimension],
+                    ['stage' => DimensionContentInterface::STAGE_LIVE, 'locale' => $locale],
+                    ExampleDimensionContent::class
+                );
                 $liveData['published'] = date('Y-m-d H:i:s');
-                $contentDataMapper->map($fillWithdefaultData($liveData), $liveUnlocalizedDimension, $liveLocalizedDimension);
+                $contentDataMapper->map($fillWithdefaultData($liveData), $liveDimensionContentCollection);
 
                 if ($options['create_route'] ?? false) {
                     $route = new Route();

--- a/Tests/Unit/Content/Application/ContentDataMapper/ContentDataMapperTest.php
+++ b/Tests/Unit/Content/Application/ContentDataMapper/ContentDataMapperTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\ContentDataMapper;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\ContentDataMapperInterface;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMapper\DataMapperInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
 
 class ContentDataMapperTest extends TestCase
 {
@@ -40,31 +41,11 @@ class ContentDataMapperTest extends TestCase
         ]);
 
         $data = ['test-key' => 'test-value'];
-        $unlocalizedObject = $this->prophesize(\stdClass::class);
-        $localizedObject = $this->prophesize(\stdClass::class);
+        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
 
-        $dataMapper1->map($data, $unlocalizedObject->reveal(), $localizedObject->reveal())->shouldBeCalled();
-        $dataMapper2->map($data, $unlocalizedObject->reveal(), $localizedObject->reveal())->shouldBeCalled();
+        $dataMapper1->map($data, $dimensionContentCollection->reveal())->shouldBeCalled();
+        $dataMapper2->map($data, $dimensionContentCollection->reveal())->shouldBeCalled();
 
-        $contentDataMapper->map($data, $unlocalizedObject, $localizedObject);
-    }
-
-    public function testMapWithoutLocalizedObject(): void
-    {
-        $dataMapper1 = $this->prophesize(DataMapperInterface::class);
-        $dataMapper2 = $this->prophesize(DataMapperInterface::class);
-
-        $contentDataMapper = $this->createContentDataMapperInstance([
-            $dataMapper1->reveal(),
-            $dataMapper2->reveal(),
-        ]);
-
-        $data = ['test-key' => 'test-value'];
-        $unlocalizedObject = $this->prophesize(\stdClass::class);
-
-        $dataMapper1->map($data, $unlocalizedObject->reveal(), null)->shouldBeCalled();
-        $dataMapper2->map($data, $unlocalizedObject->reveal(), null)->shouldBeCalled();
-
-        $contentDataMapper->map($data, $unlocalizedObject);
+        $contentDataMapper->map($data, $dimensionContentCollection->reveal());
     }
 }

--- a/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/SeoDataMapperTest.php
+++ b/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/SeoDataMapperTest.php
@@ -15,6 +15,7 @@ namespace Sulu\Bundle\ContentBundle\Tests\Unit\Content\Application\ContentDataMa
 
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMapper\SeoDataMapper;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\SeoInterface;
 
@@ -37,11 +38,18 @@ class SeoDataMapperTest extends TestCase
             'seoNoFollow' => true,
         ];
 
-        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
         $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
 
+        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
+        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
+            ->willReturn($unlocalizedDimensionContent);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
+            ->willReturn($localizedDimensionContent);
+
         $seoMapper = $this->createSeoDataMapperInstance();
-        $seoMapper->map($data, $dimensionContent->reveal(), $localizedDimensionContent->reveal());
+        $seoMapper->map($data, $dimensionContentCollection->reveal());
         $this->assertTrue(true); // Avoid risky test as this is an early return test
     }
 
@@ -59,14 +67,21 @@ class SeoDataMapperTest extends TestCase
             'seoNoFollow' => true,
         ];
 
-        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent->willImplement(SeoInterface::class);
+        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $unlocalizedDimensionContent->willImplement(SeoInterface::class);
 
         $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
 
+        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
+        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
+            ->willReturn($unlocalizedDimensionContent);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
+            ->willReturn($localizedDimensionContent);
+
         $seoMapper = $this->createSeoDataMapperInstance();
 
-        $seoMapper->map($data, $dimensionContent->reveal(), $localizedDimensionContent->reveal());
+        $seoMapper->map($data, $dimensionContentCollection->reveal());
     }
 
     public function testMapUnlocalizedSeo(): void
@@ -81,19 +96,26 @@ class SeoDataMapperTest extends TestCase
             'seoNoFollow' => true,
         ];
 
-        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent->willImplement(SeoInterface::class);
-        $dimensionContent->setSeoTitle('Seo Title')->shouldBeCalled();
-        $dimensionContent->setSeoDescription('Seo Description')->shouldBeCalled();
-        $dimensionContent->setSeoKeywords('Seo Keyword 1, Seo Keyword 2')->shouldBeCalled();
-        $dimensionContent->setSeoCanonicalUrl('http://example.localhost')->shouldBeCalled();
-        $dimensionContent->setSeoHideInSitemap(true)->shouldBeCalled();
-        $dimensionContent->setSeoNoIndex(true)->shouldBeCalled();
-        $dimensionContent->setSeoNoFollow(true)->shouldBeCalled();
+        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $unlocalizedDimensionContent->willImplement(SeoInterface::class);
+        $unlocalizedDimensionContent->setSeoTitle('Seo Title')->shouldBeCalled();
+        $unlocalizedDimensionContent->setSeoDescription('Seo Description')->shouldBeCalled();
+        $unlocalizedDimensionContent->setSeoKeywords('Seo Keyword 1, Seo Keyword 2')->shouldBeCalled();
+        $unlocalizedDimensionContent->setSeoCanonicalUrl('http://example.localhost')->shouldBeCalled();
+        $unlocalizedDimensionContent->setSeoHideInSitemap(true)->shouldBeCalled();
+        $unlocalizedDimensionContent->setSeoNoIndex(true)->shouldBeCalled();
+        $unlocalizedDimensionContent->setSeoNoFollow(true)->shouldBeCalled();
+
+        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
+        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
+            ->willReturn($unlocalizedDimensionContent);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
+            ->willReturn(null);
 
         $seoMapper = $this->createSeoDataMapperInstance();
 
-        $seoMapper->map($data, $dimensionContent->reveal());
+        $seoMapper->map($data, $dimensionContentCollection->reveal());
     }
 
     public function testMapLocalizedSeo(): void
@@ -108,8 +130,8 @@ class SeoDataMapperTest extends TestCase
             'seoNoFollow' => true,
         ];
 
-        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent->willImplement(SeoInterface::class);
+        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $unlocalizedDimensionContent->willImplement(SeoInterface::class);
 
         $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
         $localizedDimensionContent->willImplement(SeoInterface::class);
@@ -121,8 +143,15 @@ class SeoDataMapperTest extends TestCase
         $localizedDimensionContent->setSeoNoIndex(true)->shouldBeCalled();
         $localizedDimensionContent->setSeoNoFollow(true)->shouldBeCalled();
 
+        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
+        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
+            ->willReturn($unlocalizedDimensionContent);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
+            ->willReturn($localizedDimensionContent);
+
         $seoMapper = $this->createSeoDataMapperInstance();
 
-        $seoMapper->map($data, $dimensionContent->reveal(), $localizedDimensionContent->reveal());
+        $seoMapper->map($data, $dimensionContentCollection->reveal());
     }
 }

--- a/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/WorkflowDataMapperTest.php
+++ b/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/WorkflowDataMapperTest.php
@@ -16,6 +16,7 @@ namespace Sulu\Bundle\ContentBundle\Tests\Unit\Content\Application\ContentDataMa
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMapper\WorkflowDataMapper;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\WorkflowInterface;
 
@@ -34,10 +35,17 @@ class WorkflowDataMapperTest extends TestCase
             'published' => (new \DateTime())->format('c'),
         ];
 
-        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
         $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
 
-        $workflowMapper->map($data, $dimensionContent->reveal(), $localizedDimensionContent->reveal());
+        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
+        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
+            ->willReturn($unlocalizedDimensionContent);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
+            ->willReturn($localizedDimensionContent);
+
+        $workflowMapper->map($data, $dimensionContentCollection->reveal());
 
         $this->assertTrue(true); // Avoid risky test as this is an early return test
     }
@@ -50,13 +58,20 @@ class WorkflowDataMapperTest extends TestCase
             'published' => (new \DateTime())->format('c'),
         ];
 
-        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent->willImplement(WorkflowInterface::class);
+        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $unlocalizedDimensionContent->willImplement(WorkflowInterface::class);
         $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
+
+        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
+        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
+            ->willReturn($unlocalizedDimensionContent);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
+            ->willReturn($localizedDimensionContent);
 
         $this->expectException(\RuntimeException::class);
 
-        $workflowMapper->map($data, $dimensionContent->reveal(), $localizedDimensionContent->reveal());
+        $workflowMapper->map($data, $dimensionContentCollection->reveal());
     }
 
     public function testMapUnlocalizedDraft(): void
@@ -67,15 +82,22 @@ class WorkflowDataMapperTest extends TestCase
             'published' => (new \DateTime())->format('c'),
         ];
 
-        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent->willImplement(WorkflowInterface::class);
-        $dimensionContent->getStage()->willReturn(DimensionContentInterface::STAGE_DRAFT);
-        $dimensionContent->getWorkflowPlace()->willReturn(null);
+        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $unlocalizedDimensionContent->willImplement(WorkflowInterface::class);
+        $unlocalizedDimensionContent->getStage()->willReturn(DimensionContentInterface::STAGE_DRAFT);
+        $unlocalizedDimensionContent->getWorkflowPlace()->willReturn(null);
 
-        $dimensionContent->setWorkflowPlace(WorkflowInterface::WORKFLOW_PLACE_UNPUBLISHED)->shouldBeCalled();
-        $dimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
+        $unlocalizedDimensionContent->setWorkflowPlace(WorkflowInterface::WORKFLOW_PLACE_UNPUBLISHED)->shouldBeCalled();
+        $unlocalizedDimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
 
-        $workflowMapper->map($data, $dimensionContent->reveal());
+        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
+        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
+            ->willReturn($unlocalizedDimensionContent);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
+            ->willReturn(null);
+
+        $workflowMapper->map($data, $dimensionContentCollection->reveal());
     }
 
     public function testMapUnlocalizedDraftPlaceAlreadySet(): void
@@ -86,14 +108,21 @@ class WorkflowDataMapperTest extends TestCase
             'published' => (new \DateTime())->format('c'),
         ];
 
-        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent->willImplement(WorkflowInterface::class);
-        $dimensionContent->getStage()->willReturn(DimensionContentInterface::STAGE_DRAFT);
-        $dimensionContent->getWorkflowPlace()->willReturn(WorkflowInterface::WORKFLOW_PLACE_UNPUBLISHED);
-        $dimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
-        $dimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
+        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $unlocalizedDimensionContent->willImplement(WorkflowInterface::class);
+        $unlocalizedDimensionContent->getStage()->willReturn(DimensionContentInterface::STAGE_DRAFT);
+        $unlocalizedDimensionContent->getWorkflowPlace()->willReturn(WorkflowInterface::WORKFLOW_PLACE_UNPUBLISHED);
+        $unlocalizedDimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
+        $unlocalizedDimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
 
-        $workflowMapper->map($data, $dimensionContent->reveal());
+        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
+        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
+            ->willReturn($unlocalizedDimensionContent);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
+            ->willReturn(null);
+
+        $workflowMapper->map($data, $dimensionContentCollection->reveal());
     }
 
     public function testMapUnlocalizedLive(): void
@@ -104,13 +133,20 @@ class WorkflowDataMapperTest extends TestCase
             'published' => (new \DateTime())->format('c'),
         ];
 
-        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent->willImplement(WorkflowInterface::class);
-        $dimensionContent->getStage()->willReturn(DimensionContentInterface::STAGE_LIVE);
-        $dimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
-        $dimensionContent->setWorkflowPublished(Argument::type(\DateTimeInterface::class))->shouldBeCalled();
+        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $unlocalizedDimensionContent->willImplement(WorkflowInterface::class);
+        $unlocalizedDimensionContent->getStage()->willReturn(DimensionContentInterface::STAGE_LIVE);
+        $unlocalizedDimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
+        $unlocalizedDimensionContent->setWorkflowPublished(Argument::type(\DateTimeInterface::class))->shouldBeCalled();
 
-        $workflowMapper->map($data, $dimensionContent->reveal());
+        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
+        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
+            ->willReturn($unlocalizedDimensionContent);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
+            ->willReturn(null);
+
+        $workflowMapper->map($data, $dimensionContentCollection->reveal());
     }
 
     public function testMapUnlocalizedLivePublishedNotSet(): void
@@ -119,15 +155,22 @@ class WorkflowDataMapperTest extends TestCase
 
         $data = [];
 
-        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent->willImplement(WorkflowInterface::class);
-        $dimensionContent->getStage()->willReturn(DimensionContentInterface::STAGE_LIVE);
-        $dimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
-        $dimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
+        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $unlocalizedDimensionContent->willImplement(WorkflowInterface::class);
+        $unlocalizedDimensionContent->getStage()->willReturn(DimensionContentInterface::STAGE_LIVE);
+        $unlocalizedDimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
+        $unlocalizedDimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
+
+        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
+        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
+            ->willReturn($unlocalizedDimensionContent);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
+            ->willReturn(null);
 
         $this->expectException(\RuntimeException::class);
 
-        $workflowMapper->map($data, $dimensionContent->reveal());
+        $workflowMapper->map($data, $dimensionContentCollection->reveal());
     }
 
     public function testMapLocalizedDraft(): void
@@ -138,21 +181,28 @@ class WorkflowDataMapperTest extends TestCase
             'published' => (new \DateTime())->format('c'),
         ];
 
-        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent->willImplement(WorkflowInterface::class);
+        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $unlocalizedDimensionContent->willImplement(WorkflowInterface::class);
 
         $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
         $localizedDimensionContent->willImplement(WorkflowInterface::class);
         $localizedDimensionContent->getStage()->willReturn(DimensionContentInterface::STAGE_DRAFT);
         $localizedDimensionContent->getWorkflowPlace()->willReturn(null);
 
-        $dimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
-        $dimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
+        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
+        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
+            ->willReturn($unlocalizedDimensionContent);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
+            ->willReturn($localizedDimensionContent);
+
+        $unlocalizedDimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
+        $unlocalizedDimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
 
         $localizedDimensionContent->setWorkflowPlace(WorkflowInterface::WORKFLOW_PLACE_UNPUBLISHED)->shouldBeCalled();
         $localizedDimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
 
-        $workflowMapper->map($data, $dimensionContent->reveal(), $localizedDimensionContent->reveal());
+        $workflowMapper->map($data, $dimensionContentCollection->reveal());
     }
 
     public function testMapLocalizedDraftPlaceAlreadySet(): void
@@ -163,21 +213,28 @@ class WorkflowDataMapperTest extends TestCase
             'published' => (new \DateTime())->format('c'),
         ];
 
-        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent->willImplement(WorkflowInterface::class);
+        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $unlocalizedDimensionContent->willImplement(WorkflowInterface::class);
 
         $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
         $localizedDimensionContent->willImplement(WorkflowInterface::class);
         $localizedDimensionContent->getStage()->willReturn(DimensionContentInterface::STAGE_DRAFT);
         $localizedDimensionContent->getWorkflowPlace()->willReturn(WorkflowInterface::WORKFLOW_PLACE_UNPUBLISHED);
 
-        $dimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
-        $dimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
+        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
+        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
+            ->willReturn($unlocalizedDimensionContent);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
+            ->willReturn($localizedDimensionContent);
+
+        $unlocalizedDimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
+        $unlocalizedDimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
 
         $localizedDimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
         $localizedDimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
 
-        $workflowMapper->map($data, $dimensionContent->reveal(), $localizedDimensionContent->reveal());
+        $workflowMapper->map($data, $dimensionContentCollection->reveal());
     }
 
     public function testMapLocalizedLive(): void
@@ -188,20 +245,27 @@ class WorkflowDataMapperTest extends TestCase
             'published' => (new \DateTime())->format('c'),
         ];
 
-        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent->willImplement(WorkflowInterface::class);
+        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $unlocalizedDimensionContent->willImplement(WorkflowInterface::class);
 
         $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
         $localizedDimensionContent->willImplement(WorkflowInterface::class);
         $localizedDimensionContent->getStage()->willReturn(DimensionContentInterface::STAGE_LIVE);
 
-        $dimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
-        $dimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
+        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
+        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
+            ->willReturn($unlocalizedDimensionContent);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
+            ->willReturn($localizedDimensionContent);
+
+        $unlocalizedDimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
+        $unlocalizedDimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
 
         $localizedDimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
         $localizedDimensionContent->setWorkflowPublished(Argument::type(\DateTimeInterface::class))->shouldBeCalled();
 
-        $workflowMapper->map($data, $dimensionContent->reveal(), $localizedDimensionContent->reveal());
+        $workflowMapper->map($data, $dimensionContentCollection->reveal());
     }
 
     public function testMapLocalizedLivePublishedNotSet(): void
@@ -210,21 +274,28 @@ class WorkflowDataMapperTest extends TestCase
 
         $data = [];
 
-        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent->willImplement(WorkflowInterface::class);
+        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $unlocalizedDimensionContent->willImplement(WorkflowInterface::class);
 
         $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
         $localizedDimensionContent->willImplement(WorkflowInterface::class);
         $localizedDimensionContent->getStage()->willReturn(DimensionContentInterface::STAGE_LIVE);
 
-        $dimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
-        $dimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
+        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
+        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
+            ->willReturn($unlocalizedDimensionContent);
+        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
+            ->willReturn($localizedDimensionContent);
+
+        $unlocalizedDimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
+        $unlocalizedDimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
 
         $localizedDimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
         $localizedDimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
 
         $this->expectException(\RuntimeException::class);
 
-        $workflowMapper->map($data, $dimensionContent->reveal(), $localizedDimensionContent->reveal());
+        $workflowMapper->map($data, $dimensionContentCollection->reveal());
     }
 }

--- a/Tests/Unit/Content/Application/ContentWorkflow/ContentWorkflowTest.php
+++ b/Tests/Unit/Content/Application/ContentWorkflow/ContentWorkflowTest.php
@@ -81,10 +81,10 @@ class ContentWorkflowTest extends TestCase
         $transitionName = 'request_for_review';
 
         $dimensionContent1 = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent1->getStage()->willReturn('stage');
+        $dimensionContent1->getStage()->willReturn('draft');
         $dimensionContent1->getLocale()->willReturn(null);
         $dimensionContent2 = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent1->getStage()->willReturn('stage');
+        $dimensionContent1->getStage()->willReturn('draft');
         $dimensionContent1->getLocale()->willReturn('de');
 
         $this->expectExceptionMessage(sprintf(

--- a/Tests/Unit/Content/Application/ContentWorkflow/Subscriber/UnpublishTransitionSubscriberTest.php
+++ b/Tests/Unit/Content/Application/ContentWorkflow/Subscriber/UnpublishTransitionSubscriberTest.php
@@ -156,7 +156,7 @@ class UnpublishTransitionSubscriberTest extends TestCase
         );
 
         $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getLocalizedDimensionContent()
+        $dimensionContentCollection->getDimensionContent(['locale' => 'en', 'stage' => 'live'])
             ->willReturn(null)
             ->shouldBeCalled();
 
@@ -197,10 +197,10 @@ class UnpublishTransitionSubscriberTest extends TestCase
             $entityManager->reveal()
         );
 
+        $localizedLiveDimensionContent = $this->prophesize(DimensionContentInterface::class);
         $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContentCollection->getLocalizedDimensionContent()
-            ->willReturn($localizedDimensionContent)
+        $dimensionContentCollection->getDimensionContent(['locale' => 'en', 'stage' => 'live'])
+            ->willReturn($localizedLiveDimensionContent)
             ->shouldBeCalled();
 
         $liveDimensionAttributes = array_merge($dimensionAttributes, ['stage' => DimensionContentInterface::STAGE_LIVE]);
@@ -209,7 +209,7 @@ class UnpublishTransitionSubscriberTest extends TestCase
             ->willReturn($dimensionContentCollection)
             ->shouldBeCalled();
 
-        $entityManager->remove($localizedDimensionContent)->shouldBeCalled();
+        $entityManager->remove($localizedLiveDimensionContent)->shouldBeCalled();
 
         $contentUnpublishSubscriber->onUnpublish($event);
     }

--- a/Tests/Unit/Content/Application/DimensionContentCollectionFactory/DimensionContentCollectionFactoryTest.php
+++ b/Tests/Unit/Content/Application/DimensionContentCollectionFactory/DimensionContentCollectionFactoryTest.php
@@ -19,8 +19,10 @@ use Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\ContentDataM
 use Sulu\Bundle\ContentBundle\Content\Application\DimensionContentCollectionFactory\DimensionContentCollectionFactory;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentRichEntityInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollection;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Repository\DimensionContentRepositoryInterface;
+use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Preview\PreviewDimensionContentCollection;
 use Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 
@@ -72,7 +74,14 @@ class DimensionContentCollectionFactoryTest extends TestCase
         ];
 
         $contentDataMapper = $this->prophesize(ContentDataMapperInterface::class);
-        $contentDataMapper->map($data, $dimensionContent1->reveal(), $dimensionContent2->reveal())->shouldBeCalled();
+        $contentDataMapper->map(
+            $data,
+            Argument::that(
+                function (DimensionContentCollectionInterface $collection) use ($dimensionContent1, $dimensionContent2) {
+                    return [$dimensionContent1->reveal(), $dimensionContent2->reveal()] === iterator_to_array($collection);
+                }
+            )
+        )->shouldBeCalled();
 
         $dimensionContentCollectionFactoryInstance = $this->createDimensionContentCollectionFactoryInstance(
             $attributes,
@@ -89,10 +98,13 @@ class DimensionContentCollectionFactoryTest extends TestCase
             $data
         );
 
-        $this->assertSame([
-            $dimensionContent1->reveal(),
-            $dimensionContent2->reveal(),
-        ], iterator_to_array($dimensionContentCollection));
+        $this->assertCount(2, $dimensionContentCollection);
+        $this->assertSame(ExampleDimensionContent::class, $dimensionContentCollection->getDimensionContentClass());
+        $this->assertSame($attributes, $dimensionContentCollection->getDimensionAttributes());
+        $this->assertSame(
+            [$dimensionContent1->reveal(), $dimensionContent2->reveal()],
+            iterator_to_array($dimensionContentCollection)
+        );
     }
 
     public function testCreateWithoutExistingDimensionContent(): void
@@ -128,7 +140,14 @@ class DimensionContentCollectionFactoryTest extends TestCase
         ];
 
         $contentDataMapper = $this->prophesize(ContentDataMapperInterface::class);
-        $contentDataMapper->map($data, $dimensionContent1->reveal(), $dimensionContent2->reveal())->shouldBeCalled();
+        $contentDataMapper->map(
+            $data,
+            Argument::that(
+                function (DimensionContentCollectionInterface $collection) use ($dimensionContent1, $dimensionContent2) {
+                    return [$dimensionContent1->reveal(), $dimensionContent2->reveal()] === iterator_to_array($collection);
+                }
+            )
+        )->shouldBeCalled();
 
         $dimensionContentCollectionFactoryInstance = $this->createDimensionContentCollectionFactoryInstance(
             $attributes,
@@ -144,11 +163,12 @@ class DimensionContentCollectionFactoryTest extends TestCase
         );
 
         $this->assertCount(2, $dimensionContentCollection);
-
-        $this->assertSame([
-            $dimensionContent1->reveal(),
-            $dimensionContent2->reveal(),
-        ], iterator_to_array($dimensionContentCollection));
+        $this->assertSame(ExampleDimensionContent::class, $dimensionContentCollection->getDimensionContentClass());
+        $this->assertSame($attributes, $dimensionContentCollection->getDimensionAttributes());
+        $this->assertSame(
+            [$dimensionContent1->reveal(), $dimensionContent2->reveal()],
+            iterator_to_array($dimensionContentCollection)
+        );
     }
 
     public function testCreateWithoutExistingLocalizedDimensionContent(): void
@@ -178,8 +198,14 @@ class DimensionContentCollectionFactoryTest extends TestCase
         ];
 
         $contentDataMapper = $this->prophesize(ContentDataMapperInterface::class);
-        $contentDataMapper->map($data, $dimensionContent1->reveal(), $dimensionContent2->reveal())->shouldBeCalled();
-
+        $contentDataMapper->map(
+            $data,
+            Argument::that(
+                function (DimensionContentCollectionInterface $collection) use ($dimensionContent1, $dimensionContent2) {
+                    return [$dimensionContent1->reveal(), $dimensionContent2->reveal()] === iterator_to_array($collection);
+                }
+            )
+        )->shouldBeCalled();
         $dimensionContentCollectionFactoryInstance = $this->createDimensionContentCollectionFactoryInstance(
             $attributes,
             [
@@ -195,10 +221,11 @@ class DimensionContentCollectionFactoryTest extends TestCase
         );
 
         $this->assertCount(2, $dimensionContentCollection);
-
-        $this->assertSame([
-            $dimensionContent1->reveal(),
-            $dimensionContent2->reveal(),
-        ], iterator_to_array($dimensionContentCollection));
+        $this->assertSame(ExampleDimensionContent::class, $dimensionContentCollection->getDimensionContentClass());
+        $this->assertSame($attributes, $dimensionContentCollection->getDimensionAttributes());
+        $this->assertSame(
+            [$dimensionContent1->reveal(), $dimensionContent2->reveal()],
+            iterator_to_array($dimensionContentCollection)
+        );
     }
 }

--- a/Tests/Unit/Content/Application/DimensionContentCollectionFactory/DimensionContentCollectionFactoryTest.php
+++ b/Tests/Unit/Content/Application/DimensionContentCollectionFactory/DimensionContentCollectionFactoryTest.php
@@ -22,7 +22,6 @@ use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollection;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Repository\DimensionContentRepositoryInterface;
-use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Preview\PreviewDimensionContentCollection;
 use Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 

--- a/Tests/Unit/Content/Domain/Model/DimensionContentCollectionTest.php
+++ b/Tests/Unit/Content/Domain/Model/DimensionContentCollectionTest.php
@@ -32,28 +32,6 @@ class DimensionContentCollectionTest extends TestCase
         return new DimensionContentCollection($dimensionContents, $dimensionAttributes, ExampleDimensionContent::class);
     }
 
-    public function testGetLocalizedDimension(): void
-    {
-        $dimensionContent1 = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent1->getLocale()->willReturn(null);
-        $dimensionContent1->getStage()->willReturn('draft');
-        $dimensionContent2 = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent2->getLocale()->willReturn('de');
-        $dimensionContent2->getStage()->willReturn('draft');
-
-        $attributes = ['locale' => 'de'];
-
-        $dimensionContentCollection = $this->createDimensionContentCollectionInstance([
-            $dimensionContent1->reveal(),
-            $dimensionContent2->reveal(),
-        ], $attributes);
-
-        $this->assertSame(
-            $dimensionContent2->reveal(),
-            $dimensionContentCollection->getLocalizedDimensionContent()
-        );
-    }
-
     public function testCount(): void
     {
         $dimensionContent1 = $this->prophesize(DimensionContentInterface::class);

--- a/Tests/Unit/Content/Domain/Model/DimensionContentCollectionTest.php
+++ b/Tests/Unit/Content/Domain/Model/DimensionContentCollectionTest.php
@@ -32,28 +32,6 @@ class DimensionContentCollectionTest extends TestCase
         return new DimensionContentCollection($dimensionContents, $dimensionAttributes, ExampleDimensionContent::class);
     }
 
-    public function testGetUnlocalizedDimension(): void
-    {
-        $dimensionContent1 = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent1->getLocale()->willReturn(null);
-        $dimensionContent1->getStage()->willReturn('draft');
-        $dimensionContent2 = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent2->getLocale()->willReturn('de');
-        $dimensionContent2->getStage()->willReturn('draft');
-
-        $attributes = ['locale' => 'de'];
-
-        $dimensionContentCollection = $this->createDimensionContentCollectionInstance([
-            $dimensionContent1->reveal(),
-            $dimensionContent2->reveal(),
-        ], $attributes);
-
-        $this->assertSame(
-            $dimensionContent1->reveal(),
-            $dimensionContentCollection->getUnlocalizedDimensionContent()
-        );
-    }
-
     public function testGetLocalizedDimension(): void
     {
         $dimensionContent1 = $this->prophesize(DimensionContentInterface::class);

--- a/Tests/Unit/Content/Infrastructure/Sulu/Preview/ContentObjectProviderTest.php
+++ b/Tests/Unit/Content/Infrastructure/Sulu/Preview/ContentObjectProviderTest.php
@@ -29,7 +29,6 @@ use Sulu\Bundle\ContentBundle\Content\Domain\Model\TemplateInterface;
 use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Preview\ContentObjectProvider;
 use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Preview\PreviewDimensionContentCollection;
 use Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\Example;
-use Sulu\Component\Content\Document\Structure\PropertyValue;
 
 class ContentObjectProviderTest extends TestCase
 {

--- a/Tests/Unit/Content/Infrastructure/Sulu/Preview/ContentObjectProviderTest.php
+++ b/Tests/Unit/Content/Infrastructure/Sulu/Preview/ContentObjectProviderTest.php
@@ -27,7 +27,9 @@ use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentRichEntityInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\TemplateInterface;
 use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Preview\ContentObjectProvider;
+use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Preview\PreviewDimensionContentCollection;
 use Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\Example;
+use Sulu\Component\Content\Document\Structure\PropertyValue;
 
 class ContentObjectProviderTest extends TestCase
 {
@@ -197,7 +199,12 @@ class ContentObjectProviderTest extends TestCase
         $this->contentObjectProvider->setValues($dimensionContent->reveal(), $locale, $data);
 
         $this->contentDataMapper->map(
-            $data, $dimensionContent->reveal(), $dimensionContent->reveal()
+            $data,
+            Argument::that(
+                function (PreviewDimensionContentCollection $dimensionContentCollection) use ($dimensionContent) {
+                    return $dimensionContent->reveal() === $dimensionContentCollection->getDimensionContent([]);
+                }
+            )
         )->shouldBeCalledTimes(1);
     }
 

--- a/Tests/Unit/Content/Infrastructure/Sulu/Preview/PreviewDimensionContentCollectionTest.php
+++ b/Tests/Unit/Content/Infrastructure/Sulu/Preview/PreviewDimensionContentCollectionTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Tests\Unit\Content\Infrastructure\Sulu\Structure;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Preview\PreviewDimensionContentCollection;
+use Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\Example;
+use Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
+
+class PreviewDimensionContentCollectionTest extends TestCase
+{
+    protected function createPreviewDimensionContentCollection(
+        ?DimensionContentInterface $previewDimensionContent = null,
+        string $locale = 'en'
+    ): PreviewDimensionContentCollection {
+        return new PreviewDimensionContentCollection(
+            $previewDimensionContent ?: $this->prophesize(DimensionContentInterface::class)->reveal(),
+            $locale
+        );
+    }
+
+    public function testGetDimensionContentClass(): void
+    {
+        $example = $this->prophesize(Example::class);
+        $dimensionContent = new ExampleDimensionContent($example->reveal());
+
+        $previewDimensionContentCollection = $this->createPreviewDimensionContentCollection($dimensionContent);
+
+        $this->assertSame(
+            ExampleDimensionContent::class,
+            $previewDimensionContentCollection->getDimensionContentClass()
+        );
+    }
+
+    public function testGetDimensionContent(): void
+    {
+        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
+
+        $previewDimensionContentCollection = $this->createPreviewDimensionContentCollection($dimensionContent->reveal());
+
+        $this->assertSame(
+            $dimensionContent->reveal(),
+            $previewDimensionContentCollection->getDimensionContent([])
+        );
+        $this->assertSame(
+            $dimensionContent->reveal(),
+            $previewDimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
+        );
+        $this->assertSame(
+            $dimensionContent->reveal(),
+            $previewDimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'en'])
+        );
+    }
+
+    public function testGetDimensionAttributes(): void
+    {
+        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
+
+        $previewDimensionContentCollection = $this->createPreviewDimensionContentCollection(
+            $dimensionContent->reveal(),
+            'es'
+        );
+
+        $this->assertSame(
+            ['locale' => 'es'],
+            $previewDimensionContentCollection->getDimensionAttributes()
+        );
+    }
+
+    public function testGetIterator(): void
+    {
+        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
+
+        $previewDimensionContentCollection = $this->createPreviewDimensionContentCollection($dimensionContent->reveal());
+
+        $this->assertSame(
+            [$dimensionContent->reveal()],
+            iterator_to_array($previewDimensionContentCollection)
+        );
+    }
+
+    public function testGetCount(): void
+    {
+        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
+
+        $previewDimensionContentCollection = $this->createPreviewDimensionContentCollection($dimensionContent->reveal());
+
+        $this->assertCount(1, $previewDimensionContentCollection);
+    }
+}

--- a/Tests/Unit/Content/Infrastructure/Sulu/Preview/PreviewDimensionContentCollectionTest.php
+++ b/Tests/Unit/Content/Infrastructure/Sulu/Preview/PreviewDimensionContentCollectionTest.php
@@ -66,15 +66,16 @@ class PreviewDimensionContentCollectionTest extends TestCase
 
     public function testGetDimensionAttributes(): void
     {
-        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $example = $this->prophesize(Example::class);
+        $dimensionContent = new ExampleDimensionContent($example->reveal());
 
         $previewDimensionContentCollection = $this->createPreviewDimensionContentCollection(
-            $dimensionContent->reveal(),
+            $dimensionContent,
             'es'
         );
 
         $this->assertSame(
-            ['locale' => 'es'],
+            ['locale' => 'es', 'stage' => 'draft'],
             $previewDimensionContentCollection->getDimensionAttributes()
         );
     }

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,31 @@
 
 ## 0.5.0
 
+### Adjusted ContentDataMapper to accept DimensionContentCollection instead of separate objects
+
+The `ContentDataMapper` service was adjusted to accept a `DimensionContentCollection` parameter instead of 
+a `unlocalizedObject` and an optional `localizedObject` parameter. This makes the interfaces more flexible 
+and consistent to other parts of the bundle.
+
+### Adjusted DataMapperInterface to accept DimensionContentCollection instead of separate objects
+
+The `DataMapperInterface` and all services that implement the interface were adjusted to accept a 
+`DimensionContentCollection` parameter instead of a `unlocalizedObject` and an optional `localizedObject` parameter.
+
+### Removed getUnlocalizedDimensionContent and getLocalizedDimensionContent from DimensionContentCollectionInterface
+
+To simplify the interface, the `getUnlocalizedDimensionContent` method and `getLocalizedDimensionContent` method 
+were removed from the `DimensionContentCollectionInterface`. The `getDimensionContent` can be used as a
+replacement like this:
+
+```php
+$localizedDimensionAttributes = $dimensionContentCollection->getDimensionAttributes();
+$localizedDimensionContent = $dimensionContentCollection->getDimensionContent($localizedDimensionAttributes);
+
+$unlocalizedDimensionAttributes = array_merge($localizedDimensionAttributes, ['locale' => null]);
+$unlocalizedDimensionContent= $dimensionContentCollection->getDimensionContent($unlocalizedDimensionAttributes);
+```
+
 ### Dimension Entity was removed
 
 The `Dimension` entity was removed because it had no additional value and did make things

--- a/composer.json
+++ b/composer.json
@@ -108,7 +108,6 @@
         "php-cs": "vendor/bin/php-cs-fixer fix --verbose --diff --dry-run",
         "php-cs-fix": "vendor/bin/php-cs-fixer fix",
         "lint-composer": "@composer validate --strict",
-        "lint-doctrine": "Tests/Application/bin/adminconsole doctrine:schema:validate",
         "lint-twig": "Tests/Application/bin/adminconsole lint:twig Tests/Application/templates",
         "lint-yaml": "Tests/Application/bin/adminconsole lint:yaml Resources/config Tests/Application/config",
         "lint-container": [


### PR DESCRIPTION
This PR aadjust the `ContentDataMapper` service and the `DataMapper` services to accept a `DimensionContentCollection` parameter instead of a `unlocalizedObject` and an optional `localizedObject` parameter.

This makes the interfaces more flexible and consistent to other parts of the bundle.