### PR TITLE
Add versioning to dimension content

### DIFF
--- a/Content/Application/ContentNormalizer/Normalizer/DimensionContentNormalizer.php
+++ b/Content/Application/ContentNormalizer/Normalizer/DimensionContentNormalizer.php
@@ -28,6 +28,7 @@ class DimensionContentNormalizer implements NormalizerInterface
             'merged',
             'dimension',
             'resource',
+            'version',
         ];
     }
 

--- a/Content/Application/ContentWorkflow/ContentWorkflow.php
+++ b/Content/Application/ContentWorkflow/ContentWorkflow.php
@@ -135,9 +135,11 @@ class ContentWorkflow implements ContentWorkflowInterface
         // | New |--------->| Unpublished |                      | Review |---------->| Published  |                | draft |                             | Review draft  |
         // |     |          |             |<---------------------|        |           |            |--------------->|       |<----------------------------|               |
         // +-----+          +-------------+       reject         +--------+           +------------+  create draft  +-------+        reject draft         +---------------+
-        //                                                                              A   |    A                                                                |
-        //                                                                              +---+    |                          publish                               |
-        //                                                                             publish   +----------------------------------------------------------------+
+        //                   A   |                                                     A   |  A  |                      A                                          |
+        //                   +---+                                                     +---+  |  |       restore        |                                          |
+        //                  restore                                                   publish |  +----------------------+                                          |
+        //                                                                                    |                              publish                               |
+        //                                                                                    +--------------------------------------------------------------------+
 
         // Configures places
         $definition = $definitionBuilder

--- a/Content/Domain/Model/DimensionContentInterface.php
+++ b/Content/Domain/Model/DimensionContentInterface.php
@@ -18,6 +18,8 @@ interface DimensionContentInterface
     public const STAGE_DRAFT = 'draft';
     public const STAGE_LIVE = 'live';
 
+    public const DEFAULT_VERSION = 0;
+
     public static function getResourceKey(): string;
 
     public function getLocale(): ?string;
@@ -27,6 +29,10 @@ interface DimensionContentInterface
     public function getStage(): string;
 
     public function setStage(string $stage): void;
+
+    public function getVersion(): int;
+
+    public function setVersion(int $version): void;
 
     public function getResource(): ContentRichEntityInterface;
 

--- a/Content/Domain/Model/DimensionContentTrait.php
+++ b/Content/Domain/Model/DimensionContentTrait.php
@@ -26,6 +26,11 @@ trait DimensionContentTrait
     protected $stage = DimensionContentInterface::STAGE_DRAFT;
 
     /**
+     * @var int
+     */
+    protected $version = DimensionContentInterface::DEFAULT_VERSION;
+
+    /**
      * @var bool
      */
     private $isMerged = false;
@@ -50,6 +55,16 @@ trait DimensionContentTrait
         return $this->stage;
     }
 
+    public function setVersion(int $version): void
+    {
+        $this->version = $version;
+    }
+
+    public function getVersion(): int
+    {
+        return $this->version;
+    }
+
     public function isMerged(): bool
     {
         return $this->isMerged;
@@ -65,6 +80,7 @@ trait DimensionContentTrait
         return [
             'locale' => null,
             'stage' => DimensionContentInterface::STAGE_DRAFT,
+            'version' => DimensionContentInterface::DEFAULT_VERSION,
         ];
     }
 

--- a/Content/Domain/Repository/DimensionContentRepositoryInterface.php
+++ b/Content/Domain/Repository/DimensionContentRepositoryInterface.php
@@ -25,4 +25,16 @@ interface DimensionContentRepositoryInterface
         ContentRichEntityInterface $contentRichEntity,
         array $dimensionAttributes
     ): DimensionContentCollectionInterface;
+
+    public function getLatestVersion(ContentRichEntityInterface $contentRichEntity): int;
+
+    /**
+     * @param mixed[] $dimensionAttributes
+     *
+     * @return string[]
+     */
+    public function getLocales(
+        ContentRichEntityInterface $contentRichEntity,
+        array $dimensionAttributes
+    ): array;
 }

--- a/Content/Infrastructure/Doctrine/MetadataLoader.php
+++ b/Content/Infrastructure/Doctrine/MetadataLoader.php
@@ -47,6 +47,7 @@ class MetadataLoader implements EventSubscriber
         if ($reflection->implementsInterface(DimensionContentInterface::class)) {
             $this->addField($metadata, 'stage', 'string', ['length' => 16, 'nullable' => false]);
             $this->addField($metadata, 'locale', 'string', ['length' => 7, 'nullable' => true]);
+            $this->addField($metadata, 'version', 'integer', ['nullable' => false, 'default' => 0]);
         }
 
         if ($reflection->implementsInterface(SeoInterface::class)) {

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -158,6 +158,7 @@
 
         <service id="sulu_content.publish_transition_subscriber" class="Sulu\Bundle\ContentBundle\Content\Application\ContentWorkflow\Subscriber\PublishTransitionSubscriber">
             <argument type="service" id="sulu_content.content_copier"/>
+            <argument type="service" id="sulu_content.dimension_content_repository"/>
 
             <tag name="kernel.event_subscriber"/>
         </service>

--- a/Tests/Unit/Content/Application/ContentMerger/ContentMergerTest.php
+++ b/Tests/Unit/Content/Application/ContentMerger/ContentMergerTest.php
@@ -69,6 +69,8 @@ class ContentMergerTest extends TestCase
             ->shouldBeCalled();
         $mergedDimensionContent->setStage('draft')
             ->shouldBeCalled();
+        $mergedDimensionContent->setVersion(0)
+            ->shouldBeCalled();
         $mergedDimensionContent->markAsMerged()
             ->shouldBeCalled();
 

--- a/Tests/Unit/Content/Application/ContentNormalizer/Normalizer/DimensionContentNormalizerTest.php
+++ b/Tests/Unit/Content/Application/ContentNormalizer/Normalizer/DimensionContentNormalizerTest.php
@@ -42,7 +42,7 @@ class DimensionContentNormalizerTest extends TestCase
         $object = $this->prophesize(DimensionContentInterface::class);
 
         $this->assertSame(
-            ['id', 'merged', 'dimension', 'resource'],
+            ['id', 'merged', 'dimension', 'resource', 'version'],
             $normalizer->getIgnoredAttributes($object->reveal())
         );
     }

--- a/Tests/Unit/Content/Application/ContentWorkflow/ContentWorkflowTest.php
+++ b/Tests/Unit/Content/Application/ContentWorkflow/ContentWorkflowTest.php
@@ -83,9 +83,11 @@ class ContentWorkflowTest extends TestCase
         $dimensionContent1 = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent1->getStage()->willReturn('draft');
         $dimensionContent1->getLocale()->willReturn(null);
+        $dimensionContent1->getVersion()->willReturn(0);
         $dimensionContent2 = $this->prophesize(DimensionContentInterface::class);
-        $dimensionContent1->getStage()->willReturn('draft');
-        $dimensionContent1->getLocale()->willReturn('de');
+        $dimensionContent2->getStage()->willReturn('draft');
+        $dimensionContent2->getLocale()->willReturn('de');
+        $dimensionContent2->getVersion()->willReturn(0);
 
         $this->expectExceptionMessage(\sprintf(
             'Expected "%s" but "%s" given.',
@@ -166,11 +168,13 @@ class ContentWorkflowTest extends TestCase
         $dimensionContent1->willImplement(WorkflowInterface::class);
         $dimensionContent1->getLocale()->willReturn(null);
         $dimensionContent1->getStage()->willReturn('draft');
+        $dimensionContent1->getVersion()->willReturn(0);
 
         $dimensionContent2 = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent2->willImplement(WorkflowInterface::class);
         $dimensionContent2->getLocale()->willReturn('de');
         $dimensionContent2->getStage()->willReturn('draft');
+        $dimensionContent2->getVersion()->willReturn(0);
 
         $dimensionContent2->getWorkflowPlace()
             ->willReturn('unpublished')
@@ -219,10 +223,12 @@ class ContentWorkflowTest extends TestCase
         $dimensionContent1->willImplement(WorkflowInterface::class);
         $dimensionContent1->getLocale()->willReturn(null);
         $dimensionContent1->getStage()->willReturn('draft');
+        $dimensionContent1->getVersion()->willReturn(0);
         $dimensionContent2 = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent2->willImplement(WorkflowInterface::class);
         $dimensionContent2->getLocale()->willReturn('de');
         $dimensionContent2->getStage()->willReturn('draft');
+        $dimensionContent2->getVersion()->willReturn(0);
 
         $dimensionContent2->getWorkflowPlace()
             ->willReturn($currentPlace)

--- a/Tests/Unit/Content/Application/DimensionContentCollectionFactory/DimensionContentCollectionFactoryTest.php
+++ b/Tests/Unit/Content/Application/DimensionContentCollectionFactory/DimensionContentCollectionFactoryTest.php
@@ -57,15 +57,18 @@ class DimensionContentCollectionFactoryTest extends TestCase
         $dimensionContent1 = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent1->getLocale()->willReturn(null);
         $dimensionContent1->getStage()->willReturn('draft');
+        $dimensionContent1->getVersion()->willReturn(0);
         $dimensionContent2 = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent2->getLocale()->willReturn('de');
         $dimensionContent2->getStage()->willReturn('draft');
+        $dimensionContent2->getVersion()->willReturn(0);
 
         $contentRichEntity = $this->prophesize(ContentRichEntityInterface::class);
 
         $attributes = [
             'locale' => 'de',
             'stage' => 'draft',
+            'version' => 0,
         ];
 
         $data = [
@@ -113,15 +116,21 @@ class DimensionContentCollectionFactoryTest extends TestCase
             ->shouldBeCalled();
         $dimensionContent1->setStage('draft')
             ->shouldBeCalled();
+        $dimensionContent1->setVersion(0)
+            ->shouldBeCalled();
         $dimensionContent1->getLocale()->willReturn(null);
         $dimensionContent1->getStage()->willReturn('draft');
+        $dimensionContent1->getVersion()->willReturn(0);
         $dimensionContent2 = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent2->setLocale('de')
             ->shouldBeCalled();
         $dimensionContent2->setStage('draft')
             ->shouldBeCalled();
+        $dimensionContent2->setVersion(0)
+            ->shouldBeCalled();
         $dimensionContent2->getLocale()->willReturn('de');
         $dimensionContent2->getStage()->willReturn('draft');
+        $dimensionContent2->getVersion()->willReturn(0);
 
         $contentRichEntity = $this->prophesize(ContentRichEntityInterface::class);
         $contentRichEntity->createDimensionContent()->shouldBeCalledTimes(2)
@@ -132,6 +141,7 @@ class DimensionContentCollectionFactoryTest extends TestCase
         $attributes = [
             'locale' => 'de',
             'stage' => 'draft',
+            'version' => 0,
         ];
 
         $data = [
@@ -175,13 +185,17 @@ class DimensionContentCollectionFactoryTest extends TestCase
         $dimensionContent1 = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent1->getLocale()->willReturn(null);
         $dimensionContent1->getStage()->willReturn('draft');
+        $dimensionContent1->getVersion()->willReturn(0);
         $dimensionContent2 = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent2->setLocale('de')
             ->shouldBeCalled();
         $dimensionContent2->setStage('draft')
             ->shouldBeCalled();
+        $dimensionContent2->setVersion(0)
+            ->shouldBeCalled();
         $dimensionContent2->getLocale()->willReturn('de');
         $dimensionContent2->getStage()->willReturn('draft');
+        $dimensionContent2->getVersion()->willReturn(0);
 
         $contentRichEntity = $this->prophesize(ContentRichEntityInterface::class);
         $contentRichEntity->createDimensionContent()->shouldBeCalled()->willReturn($dimensionContent2->reveal());
@@ -190,6 +204,7 @@ class DimensionContentCollectionFactoryTest extends TestCase
         $attributes = [
             'locale' => 'de',
             'stage' => 'draft',
+            'version' => 0,
         ];
 
         $data = [

--- a/Tests/Unit/Content/Domain/Model/DimensionContentCollectionTest.php
+++ b/Tests/Unit/Content/Domain/Model/DimensionContentCollectionTest.php
@@ -37,9 +37,11 @@ class DimensionContentCollectionTest extends TestCase
         $dimensionContent1 = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent1->getLocale()->willReturn(null);
         $dimensionContent1->getStage()->willReturn('draft');
+        $dimensionContent1->getVersion()->willReturn(0);
         $dimensionContent2 = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent2->getLocale()->willReturn('de');
         $dimensionContent2->getStage()->willReturn('draft');
+        $dimensionContent2->getVersion()->willReturn(0);
 
         $attributes = ['locale' => 'de'];
 
@@ -58,9 +60,11 @@ class DimensionContentCollectionTest extends TestCase
         $dimensionContent1 = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent1->getLocale()->willReturn(null);
         $dimensionContent1->getStage()->willReturn('draft');
+        $dimensionContent1->getVersion()->willReturn(0);
         $dimensionContent2 = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent2->getLocale()->willReturn('de');
         $dimensionContent2->getStage()->willReturn('draft');
+        $dimensionContent2->getVersion()->willReturn(0);
 
         $attributes = ['locale' => 'de'];
 
@@ -80,9 +84,11 @@ class DimensionContentCollectionTest extends TestCase
         $dimensionContent1 = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent1->getLocale()->willReturn(null);
         $dimensionContent1->getStage()->willReturn('draft');
+        $dimensionContent1->getVersion()->willReturn(0);
         $dimensionContent2 = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent2->getLocale()->willReturn('de');
         $dimensionContent2->getStage()->willReturn('draft');
+        $dimensionContent2->getVersion()->willReturn(0);
 
         $attributes = ['locale' => 'de'];
 
@@ -102,9 +108,11 @@ class DimensionContentCollectionTest extends TestCase
         $dimensionContent1 = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent1->getLocale()->willReturn(null);
         $dimensionContent1->getStage()->willReturn('draft');
+        $dimensionContent1->getVersion()->willReturn(0);
         $dimensionContent2 = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent2->getLocale()->willReturn('de');
         $dimensionContent2->getStage()->willReturn('draft');
+        $dimensionContent2->getVersion()->willReturn(0);
 
         $attributes = ['locale' => 'de'];
 
@@ -124,9 +132,11 @@ class DimensionContentCollectionTest extends TestCase
         $dimensionContent1 = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent1->getLocale()->willReturn(null);
         $dimensionContent1->getStage()->willReturn('draft');
+        $dimensionContent1->getVersion()->willReturn(0);
         $dimensionContent2 = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent2->getLocale()->willReturn('de');
         $dimensionContent2->getStage()->willReturn('draft');
+        $dimensionContent2->getVersion()->willReturn(0);
 
         $attributes = [
             'locale' => 'de',
@@ -141,6 +151,7 @@ class DimensionContentCollectionTest extends TestCase
             [
                 'locale' => 'de',
                 'stage' => 'draft',
+                'version' => 0,
             ],
             $dimensionContentCollection->getDimensionAttributes()
         );
@@ -151,9 +162,11 @@ class DimensionContentCollectionTest extends TestCase
         $dimensionContent1 = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent1->getLocale()->willReturn(null);
         $dimensionContent1->getStage()->willReturn('draft');
+        $dimensionContent1->getVersion()->willReturn(0);
         $dimensionContent2 = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent2->getLocale()->willReturn('de');
         $dimensionContent2->getStage()->willReturn('draft');
+        $dimensionContent2->getVersion()->willReturn(0);
 
         $attributes = ['locale' => 'de'];
 
@@ -173,9 +186,11 @@ class DimensionContentCollectionTest extends TestCase
         $dimensionContent1 = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent1->getLocale()->willReturn(null);
         $dimensionContent1->getStage()->willReturn('draft');
+        $dimensionContent1->getVersion()->willReturn(0);
         $dimensionContent2 = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent2->getLocale()->willReturn('de');
         $dimensionContent2->getStage()->willReturn('draft');
+        $dimensionContent2->getVersion()->willReturn(0);
 
         $attributes = ['locale' => 'de'];
 

--- a/Tests/Unit/Content/Domain/Model/DimensionContentTraitTest.php
+++ b/Tests/Unit/Content/Domain/Model/DimensionContentTraitTest.php
@@ -59,6 +59,7 @@ class DimensionContentTraitTest extends TestCase
         $this->assertSame([
             'locale' => null,
             'stage' => 'draft',
+            'version' => 0,
         ], $model::getDefaultDimensionAttributes());
     }
 

--- a/Tests/Unit/Content/Infrastructure/Doctrine/MetadataLoaderTest.php
+++ b/Tests/Unit/Content/Infrastructure/Doctrine/MetadataLoaderTest.php
@@ -133,6 +133,7 @@ class MetadataLoaderTest extends TestCase
             [
                 'locale' => false,
                 'stage' => false,
+                'version' => false,
             ],
             [],
             [
@@ -146,6 +147,7 @@ class MetadataLoaderTest extends TestCase
             [
                 'locale' => true,
                 'stage' => true,
+                'version' => true,
             ],
             [],
             [

--- a/Tests/Unit/Content/Infrastructure/Sulu/Preview/PreviewDimensionContentCollectionTest.php
+++ b/Tests/Unit/Content/Infrastructure/Sulu/Preview/PreviewDimensionContentCollectionTest.php
@@ -75,7 +75,7 @@ class PreviewDimensionContentCollectionTest extends TestCase
         );
 
         $this->assertSame(
-            ['locale' => 'es', 'stage' => 'draft'],
+            ['locale' => 'es', 'stage' => 'draft', 'version' => 0],
             $previewDimensionContentCollection->getDimensionAttributes()
         );
     }

--- a/Tests/Unit/Mocks/DimensionContentMockWrapperTrait.php
+++ b/Tests/Unit/Mocks/DimensionContentMockWrapperTrait.php
@@ -42,6 +42,16 @@ trait DimensionContentMockWrapperTrait
         return $this->instance->getStage();
     }
 
+    public function setVersion(int $version): void
+    {
+        $this->instance->setVersion($version);
+    }
+
+    public function getVersion(): int
+    {
+        return $this->instance->getVersion();
+    }
+
     public function setStage(?string $stage): void
     {
         $this->instance->setStage($stage);


### PR DESCRIPTION
Build on top of: #190

To be discussed:

 - [ ] Optimize getPublishLocales on write?
 - [ ] Optimize getLatestVersion on write?
 - [ ] Versioning an own Interface (make getEffectiveDimensionAttributes and getDefaultDimensionAttributes more complicated is it worse?)
 - [ ] Is Restore version a workflow transition?
 - [ ] Should Version be an own Entity / Table extending from other entity? (complexity on overwrite entity (could be validated in compilerpass))
 
 TODO:
 
 - [ ] UI Versioning list on settings
 - [ ] Restore Version