### PR TITLE
Simplify data mapper with unlocalized and localized dimension content

### DIFF
--- a/Content/Application/ContentDataMapper/ContentDataMapper.php
+++ b/Content/Application/ContentDataMapper/ContentDataMapper.php
@@ -32,11 +32,23 @@ class ContentDataMapper implements ContentDataMapperInterface
     }
 
     public function map(
-        array $data,
-        DimensionContentCollectionInterface $dimensionContentCollection
+        DimensionContentCollectionInterface $dimensionContentCollection,
+        array $dimensionAttributes,
+        array $data
     ): void {
+        $localizedDimensionAttributes = $dimensionAttributes;
+        $unlocalizedDimensionAttributes = $dimensionAttributes;
+        $unlocalizedDimensionAttributes['locale'] = null;
+        $unlocalizedDimensionContent = $dimensionContentCollection->getDimensionContent($unlocalizedDimensionAttributes);
+        $localizedDimensionContent = $dimensionContentCollection->getDimensionContent($localizedDimensionAttributes);
+
+        if (!$unlocalizedDimensionContent ||!$localizedDimensionContent) {
+            // TODO see https://github.com/sulu/SuluContentBundle/pull/204
+            throw new \RuntimeException('Create unlocalized and localized dimension content.');
+        }
+
         foreach ($this->dataMappers as $mapper) {
-            $mapper->map($data, $dimensionContentCollection);
+            $mapper->map($data, $unlocalizedDimensionContent, $localizedDimensionContent);
         }
     }
 }

--- a/Content/Application/ContentDataMapper/ContentDataMapper.php
+++ b/Content/Application/ContentDataMapper/ContentDataMapper.php
@@ -48,7 +48,7 @@ class ContentDataMapper implements ContentDataMapperInterface
         }
 
         foreach ($this->dataMappers as $mapper) {
-            $mapper->map($data, $unlocalizedDimensionContent, $localizedDimensionContent);
+            $mapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
         }
     }
 }

--- a/Content/Application/ContentDataMapper/ContentDataMapper.php
+++ b/Content/Application/ContentDataMapper/ContentDataMapper.php
@@ -42,7 +42,7 @@ class ContentDataMapper implements ContentDataMapperInterface
         $unlocalizedDimensionContent = $dimensionContentCollection->getDimensionContent($unlocalizedDimensionAttributes);
         $localizedDimensionContent = $dimensionContentCollection->getDimensionContent($localizedDimensionAttributes);
 
-        if (!$unlocalizedDimensionContent ||!$localizedDimensionContent) {
+        if (!$unlocalizedDimensionContent || !$localizedDimensionContent) {
             // TODO see https://github.com/sulu/SuluContentBundle/pull/204
             throw new \RuntimeException('Create unlocalized and localized dimension content.');
         }

--- a/Content/Application/ContentDataMapper/ContentDataMapperInterface.php
+++ b/Content/Application/ContentDataMapper/ContentDataMapperInterface.php
@@ -19,9 +19,11 @@ interface ContentDataMapperInterface
 {
     /**
      * @param array<string, mixed> $data
+     * @param mixed[] $dimensionAttributes
      */
     public function map(
-        array $data,
-        DimensionContentCollectionInterface $dimensionContentCollection
+        DimensionContentCollectionInterface $dimensionContentCollection,
+        array $dimensionAttributes,
+        array $data
     ): void;
 }

--- a/Content/Application/ContentDataMapper/DataMapper/AuthorDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/AuthorDataMapper.php
@@ -16,6 +16,7 @@ namespace Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMa
 use Sulu\Bundle\ContentBundle\Content\Domain\Factory\ContactFactoryInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\AuthorInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 
 class AuthorDataMapper implements DataMapperInterface
 {
@@ -31,29 +32,14 @@ class AuthorDataMapper implements DataMapperInterface
 
     public function map(
         array $data,
-        DimensionContentCollectionInterface $dimensionContentCollection
+        DimensionContentInterface $unlocalizedDimensionContent,
+        DimensionContentInterface $localizedDimensionContent
     ): void {
-        $dimensionAttributes = $dimensionContentCollection->getDimensionAttributes();
-        $unlocalizedDimensionAttributes = \array_merge($dimensionAttributes, ['locale' => null]);
-        $unlocalizedObject = $dimensionContentCollection->getDimensionContent($unlocalizedDimensionAttributes);
-
-        if (!$unlocalizedObject instanceof AuthorInterface) {
+        if (!$localizedDimensionContent instanceof AuthorInterface) {
             return;
         }
 
-        $localizedObject = $dimensionContentCollection->getDimensionContent($dimensionAttributes);
-
-        if ($localizedObject) {
-            if (!$localizedObject instanceof AuthorInterface) {
-                throw new \RuntimeException(\sprintf('Expected "$localizedObject" from type "%s" but "%s" given.', AuthorInterface::class, \get_class($localizedObject)));
-            }
-
-            $this->setAuthorData($localizedObject, $data);
-
-            return;
-        }
-
-        $this->setAuthorData($unlocalizedObject, $data);
+        $this->setAuthorData($localizedDimensionContent, $data);
     }
 
     /**

--- a/Content/Application/ContentDataMapper/DataMapper/AuthorDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/AuthorDataMapper.php
@@ -31,13 +31,14 @@ class AuthorDataMapper implements DataMapperInterface
     }
 
     public function map(
-        array $data,
         DimensionContentInterface $unlocalizedDimensionContent,
-        DimensionContentInterface $localizedDimensionContent
+        DimensionContentInterface $localizedDimensionContent,
+        array $data
     ): void {
         if (!$localizedDimensionContent instanceof AuthorInterface) {
             return;
         }
+
 
         $this->setAuthorData($localizedDimensionContent, $data);
     }
@@ -47,11 +48,11 @@ class AuthorDataMapper implements DataMapperInterface
      */
     private function setAuthorData(AuthorInterface $dimensionContent, array $data): void
     {
-        if (isset($data['author'])) {
+        if (\array_key_exists('author', $data)) {
             $dimensionContent->setAuthor($this->contactFactory->create($data['author']));
         }
 
-        if (isset($data['authored'])) {
+        if (\array_key_exists('authored', $data)) {
             $dimensionContent->setAuthored(new \DateTimeImmutable($data['authored']));
         }
     }

--- a/Content/Application/ContentDataMapper/DataMapper/AuthorDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/AuthorDataMapper.php
@@ -15,7 +15,6 @@ namespace Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMa
 
 use Sulu\Bundle\ContentBundle\Content\Domain\Factory\ContactFactoryInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\AuthorInterface;
-use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 
 class AuthorDataMapper implements DataMapperInterface
@@ -38,7 +37,6 @@ class AuthorDataMapper implements DataMapperInterface
         if (!$localizedDimensionContent instanceof AuthorInterface) {
             return;
         }
-
 
         $this->setAuthorData($localizedDimensionContent, $data);
     }

--- a/Content/Application/ContentDataMapper/DataMapper/DataMapperInterface.php
+++ b/Content/Application/ContentDataMapper/DataMapper/DataMapperInterface.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMapper;
 
-use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 
 interface DataMapperInterface
 {
@@ -22,6 +22,7 @@ interface DataMapperInterface
      */
     public function map(
         array $data,
-        DimensionContentCollectionInterface $dimensionContentCollection
+        DimensionContentInterface $unlocalizedDimensionContent,
+        DimensionContentInterface $localizedDimensionContent
     ): void;
 }

--- a/Content/Application/ContentDataMapper/DataMapper/DataMapperInterface.php
+++ b/Content/Application/ContentDataMapper/DataMapper/DataMapperInterface.php
@@ -21,8 +21,8 @@ interface DataMapperInterface
      * @param array<string, mixed> $data
      */
     public function map(
-        array $data,
         DimensionContentInterface $unlocalizedDimensionContent,
-        DimensionContentInterface $localizedDimensionContent
+        DimensionContentInterface $localizedDimensionContent,
+        array $data
     ): void;
 }

--- a/Content/Application/ContentDataMapper/DataMapper/ExcerptDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/ExcerptDataMapper.php
@@ -15,7 +15,6 @@ namespace Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMa
 
 use Sulu\Bundle\ContentBundle\Content\Domain\Factory\CategoryFactoryInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Factory\TagFactoryInterface;
-use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ExcerptInterface;
 

--- a/Content/Application/ContentDataMapper/DataMapper/ExcerptDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/ExcerptDataMapper.php
@@ -16,6 +16,7 @@ namespace Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMa
 use Sulu\Bundle\ContentBundle\Content\Domain\Factory\CategoryFactoryInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Factory\TagFactoryInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ExcerptInterface;
 
 class ExcerptDataMapper implements DataMapperInterface
@@ -38,29 +39,14 @@ class ExcerptDataMapper implements DataMapperInterface
 
     public function map(
         array $data,
-        DimensionContentCollectionInterface $dimensionContentCollection
+        DimensionContentInterface $unlocalizedDimensionContent,
+        DimensionContentInterface $localizedDimensionContent
     ): void {
-        $dimensionAttributes = $dimensionContentCollection->getDimensionAttributes();
-        $unlocalizedDimensionAttributes = \array_merge($dimensionAttributes, ['locale' => null]);
-        $unlocalizedObject = $dimensionContentCollection->getDimensionContent($unlocalizedDimensionAttributes);
-
-        if (!$unlocalizedObject instanceof ExcerptInterface) {
+        if (!$localizedDimensionContent instanceof ExcerptInterface) {
             return;
         }
 
-        $localizedObject = $dimensionContentCollection->getDimensionContent($dimensionAttributes);
-
-        if ($localizedObject) {
-            if (!$localizedObject instanceof ExcerptInterface) {
-                throw new \RuntimeException(\sprintf('Expected "$localizedObject" from type "%s" but "%s" given.', ExcerptInterface::class, \get_class($localizedObject)));
-            }
-
-            $this->setExcerptData($localizedObject, $data);
-
-            return;
-        }
-
-        $this->setExcerptData($unlocalizedObject, $data);
+        $this->setExcerptData($localizedDimensionContent, $data);
     }
 
     /**

--- a/Content/Application/ContentDataMapper/DataMapper/ExcerptDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/ExcerptDataMapper.php
@@ -38,9 +38,9 @@ class ExcerptDataMapper implements DataMapperInterface
     }
 
     public function map(
-        array $data,
         DimensionContentInterface $unlocalizedDimensionContent,
-        DimensionContentInterface $localizedDimensionContent
+        DimensionContentInterface $localizedDimensionContent,
+        array $data
     ): void {
         if (!$localizedDimensionContent instanceof ExcerptInterface) {
             return;
@@ -54,14 +54,28 @@ class ExcerptDataMapper implements DataMapperInterface
      */
     private function setExcerptData(ExcerptInterface $dimensionContent, array $data): void
     {
-        $dimensionContent->setExcerptTitle($data['excerptTitle'] ?? null);
-        $dimensionContent->setExcerptDescription($data['excerptDescription'] ?? null);
-        $dimensionContent->setExcerptMore($data['excerptMore'] ?? null);
-        $dimensionContent->setExcerptImage($data['excerptImage'] ?? null);
-        $dimensionContent->setExcerptIcon($data['excerptIcon'] ?? null);
-        $dimensionContent->setExcerptTags($this->tagFactory->create($data['excerptTags'] ?? []));
-        $dimensionContent->setExcerptCategories(
-            $this->categoryFactory->create($data['excerptCategories'] ?? [])
-        );
+        if (\array_key_exists('excerptTitle', $data)) {
+            $dimensionContent->setExcerptTitle($data['excerptTitle']);
+        }
+        if (\array_key_exists('excerptDescription', $data)) {
+            $dimensionContent->setExcerptDescription($data['excerptDescription']);
+        }
+        if (\array_key_exists('excerptMore', $data)) {
+            $dimensionContent->setExcerptMore($data['excerptMore']);
+        }
+        if (\array_key_exists('excerptImage', $data)) {
+            $dimensionContent->setExcerptImage($data['excerptImage']);
+        }
+        if (\array_key_exists('excerptIcon', $data)) {
+            $dimensionContent->setExcerptIcon($data['excerptIcon']);
+        }
+        if (\array_key_exists('excerptTags', $data)) {
+            $dimensionContent->setExcerptTags($this->tagFactory->create($data['excerptTags'] ?: []));
+        }
+        if (\array_key_exists('excerptCategories', $data)) {
+            $dimensionContent->setExcerptCategories(
+                $this->categoryFactory->create($data['excerptCategories'] ?: [])
+            );
+        }
     }
 }

--- a/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapper.php
@@ -135,7 +135,7 @@ class RoutableDataMapper implements DataMapperInterface
         }
 
         if (null === $entityClass || null === $routeSchema) {
-            return;
+            throw new \RuntimeException(\sprintf('No route mapping found for "%s".', $resourceKey));
         }
 
         $routePath = $data[$name] ?? null;

--- a/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapper.php
@@ -76,9 +76,9 @@ class RoutableDataMapper implements DataMapperInterface
     }
 
     public function map(
-        array $data,
         DimensionContentInterface $unlocalizedDimensionContent,
-        DimensionContentInterface $localizedDimensionContent
+        DimensionContentInterface $localizedDimensionContent,
+        array $data
     ): void {
         if (!$localizedDimensionContent instanceof RoutableInterface) {
             return;

--- a/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapper.php
@@ -17,7 +17,6 @@ use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\RoutableInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\TemplateInterface;
 use Sulu\Bundle\RouteBundle\Generator\RouteGeneratorInterface;
-use Sulu\Bundle\RouteBundle\Manager\ConflictResolverInterface;
 use Sulu\Bundle\RouteBundle\Manager\RouteManagerInterface;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
 use Sulu\Component\Content\Metadata\PropertyMetadata;

--- a/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapper.php
@@ -17,6 +17,7 @@ use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\RoutableInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\TemplateInterface;
 use Sulu\Bundle\RouteBundle\Generator\RouteGeneratorInterface;
+use Sulu\Bundle\RouteBundle\Manager\ConflictResolverInterface;
 use Sulu\Bundle\RouteBundle\Manager\RouteManagerInterface;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
 use Sulu\Component\Content\Metadata\PropertyMetadata;

--- a/Content/Application/ContentDataMapper/DataMapper/SeoDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/SeoDataMapper.php
@@ -14,35 +14,21 @@ declare(strict_types=1);
 namespace Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMapper;
 
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\SeoInterface;
 
 class SeoDataMapper implements DataMapperInterface
 {
     public function map(
         array $data,
-        DimensionContentCollectionInterface $dimensionContentCollection
+        DimensionContentInterface $unlocalizedDimensionContent,
+        DimensionContentInterface $localizedDimensionContent
     ): void {
-        $dimensionAttributes = $dimensionContentCollection->getDimensionAttributes();
-        $unlocalizedDimensionAttributes = \array_merge($dimensionAttributes, ['locale' => null]);
-        $unlocalizedObject = $dimensionContentCollection->getDimensionContent($unlocalizedDimensionAttributes);
-
-        if (!$unlocalizedObject instanceof SeoInterface) {
+        if (!$localizedDimensionContent instanceof SeoInterface) {
             return;
         }
 
-        $localizedObject = $dimensionContentCollection->getDimensionContent($dimensionAttributes);
-
-        if ($localizedObject) {
-            if (!$localizedObject instanceof SeoInterface) {
-                throw new \RuntimeException(\sprintf('Expected "$localizedObject" from type "%s" but "%s" given.', SeoInterface::class, \get_class($localizedObject)));
-            }
-
-            $this->setSeoData($localizedObject, $data);
-
-            return;
-        }
-
-        $this->setSeoData($unlocalizedObject, $data);
+        $this->setSeoData($localizedDimensionContent, $data);
     }
 
     /**

--- a/Content/Application/ContentDataMapper/DataMapper/SeoDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/SeoDataMapper.php
@@ -20,9 +20,9 @@ use Sulu\Bundle\ContentBundle\Content\Domain\Model\SeoInterface;
 class SeoDataMapper implements DataMapperInterface
 {
     public function map(
-        array $data,
         DimensionContentInterface $unlocalizedDimensionContent,
-        DimensionContentInterface $localizedDimensionContent
+        DimensionContentInterface $localizedDimensionContent,
+        array $data
     ): void {
         if (!$localizedDimensionContent instanceof SeoInterface) {
             return;

--- a/Content/Application/ContentDataMapper/DataMapper/SeoDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/SeoDataMapper.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMapper;
 
-use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\SeoInterface;
 

--- a/Content/Application/ContentDataMapper/DataMapper/TemplateDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/TemplateDataMapper.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMapper;
 
-use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\TemplateInterface;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;

--- a/Content/Application/ContentDataMapper/DataMapper/WorkflowDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/WorkflowDataMapper.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMapper;
 
-use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\WorkflowInterface;
 
@@ -21,29 +20,14 @@ class WorkflowDataMapper implements DataMapperInterface
 {
     public function map(
         array $data,
-        DimensionContentCollectionInterface $dimensionContentCollection
+        DimensionContentInterface $unlocalizedDimensionContent,
+        DimensionContentInterface $localizedDimensionContent
     ): void {
-        $dimensionAttributes = $dimensionContentCollection->getDimensionAttributes();
-        $unlocalizedDimensionAttributes = \array_merge($dimensionAttributes, ['locale' => null]);
-        $unlocalizedObject = $dimensionContentCollection->getDimensionContent($unlocalizedDimensionAttributes);
-
-        if (!$unlocalizedObject instanceof WorkflowInterface) {
+        if (!$localizedDimensionContent instanceof WorkflowInterface) {
             return;
         }
 
-        $localizedObject = $dimensionContentCollection->getDimensionContent($dimensionAttributes);
-
-        if ($localizedObject) {
-            if (!$localizedObject instanceof WorkflowInterface) {
-                throw new \RuntimeException(\sprintf('Expected "$localizedObject" from type "%s" but "%s" given.', WorkflowInterface::class, \get_class($localizedObject)));
-            }
-
-            $this->setWorkflowData($localizedObject, $data);
-
-            return;
-        }
-
-        $this->setWorkflowData($unlocalizedObject, $data);
+        $this->setWorkflowData($localizedDimensionContent, $data);
     }
 
     /**

--- a/Content/Application/ContentDataMapper/DataMapper/WorkflowDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/WorkflowDataMapper.php
@@ -31,6 +31,7 @@ class WorkflowDataMapper implements DataMapperInterface
     }
 
     /**
+     * @param WorkflowInterface&DimensionContentInterface $object
      * @param mixed[] $data
      */
     private function setWorkflowData(WorkflowInterface $object, array $data): void
@@ -40,6 +41,7 @@ class WorkflowDataMapper implements DataMapperInterface
     }
 
     /**
+     * @param WorkflowInterface&DimensionContentInterface $object
      * @param mixed[] $data
      */
     private function setInitialPlaceToDraftDimension(WorkflowInterface $object, array $data): void
@@ -48,8 +50,7 @@ class WorkflowDataMapper implements DataMapperInterface
         // after the place was set by this mapper initially, the place should only be changed by the ContentWorkflow
         // see: https://github.com/sulu/SuluContentBundle/issues/92
 
-        if (!$object instanceof DimensionContentInterface
-            || DimensionContentInterface::STAGE_DRAFT !== $object->getStage()) {
+        if (DimensionContentInterface::STAGE_DRAFT !== $object->getStage()) {
             return;
         }
 
@@ -60,6 +61,7 @@ class WorkflowDataMapper implements DataMapperInterface
     }
 
     /**
+     * @param WorkflowInterface&DimensionContentInterface $object
      * @param mixed[] $data
      */
     private function setPublishedToLiveDimension(WorkflowInterface $object, array $data): void
@@ -67,8 +69,7 @@ class WorkflowDataMapper implements DataMapperInterface
         // the published property of the draft dimension should only be changed by a ContentWorkflow subscriber
         // therefore we only want to copy the published property from the draft to the live dimension
 
-        if (!$object instanceof DimensionContentInterface
-            || DimensionContentInterface::STAGE_LIVE !== $object->getStage()) {
+        if (DimensionContentInterface::STAGE_LIVE !== $object->getStage()) {
             return;
         }
 

--- a/Content/Application/ContentDataMapper/DataMapper/WorkflowDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/WorkflowDataMapper.php
@@ -19,9 +19,9 @@ use Sulu\Bundle\ContentBundle\Content\Domain\Model\WorkflowInterface;
 class WorkflowDataMapper implements DataMapperInterface
 {
     public function map(
-        array $data,
         DimensionContentInterface $unlocalizedDimensionContent,
-        DimensionContentInterface $localizedDimensionContent
+        DimensionContentInterface $localizedDimensionContent,
+        array $data
     ): void {
         if (!$localizedDimensionContent instanceof WorkflowInterface) {
             return;

--- a/Content/Application/DimensionContentCollectionFactory/DimensionContentCollectionFactory.php
+++ b/Content/Application/DimensionContentCollectionFactory/DimensionContentCollectionFactory.php
@@ -99,7 +99,7 @@ class DimensionContentCollectionFactory implements DimensionContentCollectionFac
             $dimensionContentCollection->getDimensionContentClass()
         );
 
-        $this->contentDataMapper->map($data, $dimensionContentCollection);
+        $this->contentDataMapper->map($dimensionContentCollection, $dimensionAttributes, $data);
 
         return $dimensionContentCollection;
     }

--- a/Content/Infrastructure/Sulu/Preview/ContentObjectProvider.php
+++ b/Content/Infrastructure/Sulu/Preview/ContentObjectProvider.php
@@ -102,7 +102,11 @@ class ContentObjectProvider implements PreviewObjectProviderInterface
     public function setValues($object, $locale, array $data): void
     {
         $previewDimensionContentCollection = new PreviewDimensionContentCollection($object, $locale);
-        $this->contentDataMapper->map($data, $previewDimensionContentCollection);
+        $this->contentDataMapper->map(
+            $previewDimensionContentCollection,
+            $previewDimensionContentCollection->getDimensionAttributes(),
+            $data
+        );
     }
 
     /**

--- a/Resources/config/data-mapper.xml
+++ b/Resources/config/data-mapper.xml
@@ -36,7 +36,6 @@
             <argument type="service" id="sulu_page.structure.factory"/>
             <argument type="service" id="sulu_route.generator.route_generator"/>
             <argument type="service" id="sulu_route.manager.route_manager"/>
-            <argument type="service" id="sulu_route.manager.conflict_resolver.auto_increment"/>
             <argument>%sulu.content.structure.default_types%</argument>
             <argument>%sulu_route.mappings%</argument>
 

--- a/Tests/Application/ExampleTestBundle/Controller/ExampleController.php
+++ b/Tests/Application/ExampleTestBundle/Controller/ExampleController.php
@@ -136,6 +136,10 @@ class ExampleController extends AbstractRestController implements ClassResourceI
     {
         $example = new Example();
 
+        $this->entityManager->persist($example);
+        // FIXME This flush is needed for RoutableMapper and should in future note longer be required
+        $this->entityManager->flush();
+
         $data = $this->getData($request);
         $dimensionAttributes = $this->getDimensionAttributes($request); // ["locale" => "en", "stage" => "draft"]
 

--- a/Tests/Application/ExampleTestBundle/Controller/ExampleController.php
+++ b/Tests/Application/ExampleTestBundle/Controller/ExampleController.php
@@ -136,10 +136,6 @@ class ExampleController extends AbstractRestController implements ClassResourceI
     {
         $example = new Example();
 
-        $this->entityManager->persist($example);
-        // FIXME This flush is needed for RoutableMapper and should in future note longer be required
-        $this->entityManager->flush();
-
         $data = $this->getData($request);
         $dimensionAttributes = $this->getDimensionAttributes($request); // ["locale" => "en", "stage" => "draft"]
 

--- a/Tests/Application/ExampleTestBundle/Entity/ExampleDimensionContent.php
+++ b/Tests/Application/ExampleTestBundle/Entity/ExampleDimensionContent.php
@@ -85,7 +85,11 @@ class ExampleDimensionContent implements DimensionContentInterface, ExcerptInter
     public function getTemplateData(): array
     {
         $data = $this->parentGetTemplateData();
-        $data['title'] = $this->getTitle();
+        $title = $this->getTitle();
+
+        if ($title) {
+            $data['title'] = $title;
+        }
 
         return $data;
     }

--- a/Tests/Application/ExampleTestBundle/Entity/ExampleDimensionContent.php
+++ b/Tests/Application/ExampleTestBundle/Entity/ExampleDimensionContent.php
@@ -37,7 +37,6 @@ class ExampleDimensionContent implements DimensionContentInterface, ExcerptInter
     use RoutableTrait;
     use SeoTrait;
     use TemplateTrait {
-        getTemplateData as parentGetTemplateData;
         setTemplateData as parentSetTemplateData;
     }
     use WorkflowTrait;
@@ -77,27 +76,12 @@ class ExampleDimensionContent implements DimensionContentInterface, ExcerptInter
         return $this->title;
     }
 
-    public function setTitle(?string $title): void
-    {
-        $this->title = $title;
-    }
-
-    public function getTemplateData(): array
-    {
-        $data = $this->parentGetTemplateData();
-        $title = $this->getTitle();
-
-        if ($title) {
-            $data['title'] = $title;
-        }
-
-        return $data;
-    }
-
     public function setTemplateData(array $templateData): void
     {
-        $this->setTitle($templateData['title'] ?? null);
-        unset($templateData['title']);
+        if (\array_key_exists('title', $templateData)) {
+            $this->title = $templateData['title'] ?? null;
+        }
+
         $this->parentSetTemplateData($templateData);
     }
 

--- a/Tests/Application/ExampleTestBundle/Entity/ExampleDimensionContent.php
+++ b/Tests/Application/ExampleTestBundle/Entity/ExampleDimensionContent.php
@@ -92,7 +92,7 @@ class ExampleDimensionContent implements DimensionContentInterface, ExcerptInter
 
     public function setTemplateData(array $templateData): void
     {
-        $this->setTitle($templateData['title']);
+        $this->setTitle($templateData['title'] ?? null);
         unset($templateData['title']);
         $this->parentSetTemplateData($templateData);
     }

--- a/Tests/Functional/Integration/ExampleControllerTest.php
+++ b/Tests/Functional/Integration/ExampleControllerTest.php
@@ -140,7 +140,7 @@ class ExampleControllerTest extends SuluTestCase
         $this->assertResponseSnapshot('example_post.json', $response, 201);
 
         $routeRepository = $this->getContainer()->get('sulu.repository.route');
-        $this->assertCount(1, $routeRepository->findAll());
+        $this->assertCount(0, $routeRepository->findAll());
 
         $id = \json_decode((string) $response->getContent(), true)['id'] ?? null;
 
@@ -193,6 +193,9 @@ class ExampleControllerTest extends SuluTestCase
         ]) ?: null);
 
         $response = $this->client->getResponse();
+
+        $routeRepository = $this->getContainer()->get('sulu.repository.route');
+        $this->assertCount(0, $routeRepository->findAll());
 
         $this->assertResponseSnapshot('example_put.json', $response, 200);
     }

--- a/Tests/Functional/Integration/ExampleControllerTest.php
+++ b/Tests/Functional/Integration/ExampleControllerTest.php
@@ -140,7 +140,7 @@ class ExampleControllerTest extends SuluTestCase
         $this->assertResponseSnapshot('example_post.json', $response, 201);
 
         $routeRepository = $this->getContainer()->get('sulu.repository.route');
-        $this->assertCount(0, $routeRepository->findAll());
+        $this->assertCount(1, $routeRepository->findAll());
 
         $id = \json_decode((string) $response->getContent(), true)['id'] ?? null;
 

--- a/Tests/Functional/Traits/CreateExampleTrait.php
+++ b/Tests/Functional/Traits/CreateExampleTrait.php
@@ -56,7 +56,6 @@ trait CreateExampleTrait
         $localizedDimensionContent = $example->createDimensionContent();
         $localizedDimensionContent->setLocale($locale);
         $localizedDimensionContent->setStage($stage);
-        $localizedDimensionContent->setTitle($data['title'] ?? null);
 
         $templateKey = $data['templateKey'] ?? null;
         if ($templateKey) {

--- a/Tests/Traits/CreateExampleTrait.php
+++ b/Tests/Traits/CreateExampleTrait.php
@@ -97,7 +97,11 @@ trait CreateExampleTrait
                 ['stage' => DimensionContentInterface::STAGE_DRAFT, 'locale' => $locale],
                 ExampleDimensionContent::class
             );
-            $contentDataMapper->map($fillWithdefaultData($draftData), $draftDimensionContentCollection);
+            $contentDataMapper->map(
+                $draftDimensionContentCollection,
+                $draftDimensionContentCollection->getDimensionAttributes(),
+                $fillWithdefaultData($draftData)
+            );
             $draftLocalizedDimension->setWorkflowPlace(WorkflowInterface::WORKFLOW_PLACE_DRAFT);
 
             if ($liveData) {
@@ -134,7 +138,11 @@ trait CreateExampleTrait
                     ExampleDimensionContent::class
                 );
                 $liveData['published'] = \date('Y-m-d H:i:s');
-                $contentDataMapper->map($fillWithdefaultData($liveData), $liveDimensionContentCollection);
+                $contentDataMapper->map(
+                    $liveDimensionContentCollection,
+                    $liveDimensionContentCollection->getDimensionAttributes(),
+                    $fillWithdefaultData($liveData)
+                );
 
                 if ($options['create_route'] ?? false) {
                     $route = new Route();

--- a/Tests/Traits/SetGetPrivatePropertyTrait.php
+++ b/Tests/Traits/SetGetPrivatePropertyTrait.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Tests\Traits;
+
+trait SetGetPrivatePropertyTrait
+{
+    /**
+     * @return mixed
+     */
+    protected static function getPrivateProperty(object $object, string $propertyName)
+    {
+        $reflection = new \ReflectionClass($object);
+        $propertyReflection = $reflection->getProperty($propertyName);
+        $propertyReflection->setAccessible(true);
+
+        return $propertyReflection->getValue($object);
+    }
+
+    /**
+     * @param mixed $value
+     */
+    protected static function setPrivateProperty(object $object, string $propertyName, $value): void
+    {
+        $reflection = new \ReflectionClass($object);
+        $propertyReflection = $reflection->getProperty($propertyName);
+        $propertyReflection->setAccessible(true);
+
+        $propertyReflection->setValue($object, $value);
+    }
+}

--- a/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/AuthorDataMapperTest.php
+++ b/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/AuthorDataMapperTest.php
@@ -13,24 +13,34 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\ContentBundle\Tests\Unit\Content\Application\ContentDataMapper\DataMapper;
 
-use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
-use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\ContactBundle\Entity\Contact;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMapper\AuthorDataMapper;
 use Sulu\Bundle\ContentBundle\Content\Domain\Factory\ContactFactoryInterface;
-use Sulu\Bundle\ContentBundle\Content\Domain\Model\AuthorInterface;
-use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\Example;
+use Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
 
 class AuthorDataMapperTest extends TestCase
 {
-    protected function createAuthorDataMapperInstance(ContactFactoryInterface $contactFactory): AuthorDataMapper
+    /**
+     * @var ObjectProphecy|ContactFactoryInterface
+     */
+    private $contactFactory;
+
+    protected function setUp(): void
     {
-        return new AuthorDataMapper($contactFactory);
+        $this->contactFactory = $this->prophesize(ContactFactoryInterface::class);
     }
 
-    public function testMapNoAuthor(): void
+    protected function createAuthorDataMapperInstance(): AuthorDataMapper
+    {
+        return new AuthorDataMapper($this->contactFactory->reveal());
+    }
+
+    public function testMapNoAuthorInterface(): void
     {
         $data = [
             'author' => 1,
@@ -38,123 +48,56 @@ class AuthorDataMapperTest extends TestCase
         ];
 
         $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()
-            ->shouldBeCalled()
-            ->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->shouldBeCalled()
-            ->willReturn($unlocalizedDimensionContent);
-
-        $contactFactory = $this->prophesize(ContactFactoryInterface::class);
-
-        $authorMapper = $this->createAuthorDataMapperInstance($contactFactory->reveal());
-        $authorMapper->map($data, $dimensionContentCollection->reveal());
-    }
-
-    public function testMapLocalizedNoAuthor(): void
-    {
-        $data = [
-            'author' => 1,
-            'authored' => '2020-05-08T00:00:00+00:00',
-        ];
-
-        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $unlocalizedDimensionContent->willImplement(AuthorInterface::class);
-
         $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
 
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()
-            ->shouldBeCalled()
-            ->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn($localizedDimensionContent->reveal());
-
         $contactFactory = $this->prophesize(ContactFactoryInterface::class);
+        $contactFactory->create(Argument::any())
+            ->shouldNotBeCalled();
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Expected "$localizedObject" from type "Sulu\Bundle\ContentBundle\Content\Domain\Model\AuthorInterface" but "Double\DimensionContentInterface\P3" given.');
-
-        $authorMapper = $this->createAuthorDataMapperInstance($contactFactory->reveal());
-        $authorMapper->map($data, $dimensionContentCollection->reveal());
+        $authorMapper = $this->createAuthorDataMapperInstance();
+        $authorMapper->map($unlocalizedDimensionContent->reveal(), $localizedDimensionContent->reveal(), $data);
     }
 
-    public function testMapUnlocalizedAuthor(): void
+    public function testMapAuthorNoData(): void
+    {
+        $data = [];
+
+        $example = new Example();
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+
+        $this->contactFactory->create(Argument::any())
+            ->shouldNotBeCalled();
+
+        $authorMapper = $this->createAuthorDataMapperInstance();
+        $authorMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertNull($localizedDimensionContent->getAuthor());
+        $this->assertNull($localizedDimensionContent->getAuthored());
+    }
+
+    public function testMapData(): void
     {
         $data = [
             'author' => 1,
             'authored' => '2020-05-08T00:00:00+00:00',
         ];
-        $contact = $this->prophesize(ContactInterface::class);
-        $contactFactory = $this->prophesize(ContactFactoryInterface::class);
-        $contactFactory->create(1)
+
+        $example = new Example();
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+
+        $contact = new Contact();
+        $this->contactFactory->create(1)
             ->shouldBeCalled()
-            ->willReturn($contact->reveal());
+            ->willReturn($contact);
 
-        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $unlocalizedDimensionContent->willImplement(AuthorInterface::class);
+        $authorMapper = $this->createAuthorDataMapperInstance();
+        $authorMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
 
-        $unlocalizedDimensionContent->setAuthor($contact->reveal())
-            ->shouldBeCalled();
-        $unlocalizedDimensionContent->setAuthored(Argument::that(
-            function(DateTimeImmutable $date) {
-                return $date->getTimestamp() === (new \DateTimeImmutable('2020-05-08T00:00:00+00:00'))->getTimestamp();
-            })
-        )->shouldBeCalled();
-
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()
-            ->shouldBeCalled()
-            ->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent->reveal());
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn(null);
-
-        $authorMapper = $this->createAuthorDataMapperInstance($contactFactory->reveal());
-        $authorMapper->map($data, $dimensionContentCollection->reveal());
-    }
-
-    public function testMapLocalizedAuthor(): void
-    {
-        $data = [
-            'author' => 1,
-            'authored' => '2020-05-08T00:00:00+00:00',
-        ];
-        $contact = $this->prophesize(ContactInterface::class);
-        $contactFactory = $this->prophesize(ContactFactoryInterface::class);
-        $contactFactory->create(1)
-            ->shouldBeCalled()
-            ->willReturn($contact->reveal());
-
-        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $unlocalizedDimensionContent->willImplement(AuthorInterface::class);
-
-        $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent->willImplement(AuthorInterface::class);
-
-        $localizedDimensionContent->setAuthor($contact->reveal())
-            ->shouldBeCalled();
-        $localizedDimensionContent->setAuthored(Argument::that(
-            function(DateTimeImmutable $date) {
-                return $date->getTimestamp() === (new \DateTimeImmutable('2020-05-08T00:00:00+00:00'))->getTimestamp();
-            })
-        )->shouldBeCalled();
-
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()
-            ->shouldBeCalled()
-            ->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent->reveal());
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn($localizedDimensionContent->reveal());
-
-        $authorMapper = $this->createAuthorDataMapperInstance($contactFactory->reveal());
-        $authorMapper->map($data, $dimensionContentCollection->reveal());
+        $this->assertSame($contact, $localizedDimensionContent->getAuthor());
+        $authored = $localizedDimensionContent->getAuthored();
+        $this->assertNotNull($authored);
+        $this->assertSame('2020-05-08T00:00:00+00:00', $authored->format('c'));
     }
 }

--- a/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/ExcerptDataMapperTest.php
+++ b/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/ExcerptDataMapperTest.php
@@ -20,13 +20,10 @@ use Sulu\Bundle\CategoryBundle\Entity\Category;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMapper\ExcerptDataMapper;
 use Sulu\Bundle\ContentBundle\Content\Domain\Factory\CategoryFactoryInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Factory\TagFactoryInterface;
-use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
-use Sulu\Bundle\ContentBundle\Content\Domain\Model\ExcerptInterface;
 use Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\Example;
 use Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
 use Sulu\Bundle\TagBundle\Entity\Tag;
-use Sulu\Bundle\TagBundle\Tag\TagInterface;
 
 class ExcerptDataMapperTest extends TestCase
 {
@@ -46,7 +43,8 @@ class ExcerptDataMapperTest extends TestCase
         $this->categoryFactory = $this->prophesize(CategoryFactoryInterface::class);
     }
 
-    protected function createExcerptDataMapperInstance(): ExcerptDataMapper {
+    protected function createExcerptDataMapperInstance(): ExcerptDataMapper
+    {
         return new ExcerptDataMapper($this->tagFactory->reveal(), $this->categoryFactory->reveal());
     }
 

--- a/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapperTest.php
+++ b/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapperTest.php
@@ -220,34 +220,6 @@ class RoutableDataMapperTest extends TestCase
         $this->assertSame([], $localizedDimensionContent->getTemplateData());
     }
 
-    public function testMapNoResourceId(): void
-    {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Expected a LocalizedDimensionContent with a resourceId.');
-
-        $data = [
-            'template' => 'default',
-        ];
-
-        $example = new Example();
-        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
-        $localizedDimensionContent = new ExampleDimensionContent($example);
-        $localizedDimensionContent->setLocale('en');
-
-        $this->structureMetadataFactory->getStructureMetadata('example', 'default')
-            ->shouldBeCalled()
-            ->willReturn($this->createRouteStructureMetadata());
-
-        $this->routeManager->createOrUpdateByAttributes(Argument::cetera())->shouldNotBeCalled();
-        $this->routeGenerator->generate(Argument::cetera())
-            ->shouldNotBeCalled();
-
-        $mapper = $this->createRouteDataMapperInstance();
-        $mapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
-
-        $this->assertSame([], $localizedDimensionContent->getTemplateData());
-    }
-
     public function testMapNoRoutePropertyValue(): void
     {
         // see https://github.com/sulu/SuluContentBundle/pull/55
@@ -310,6 +282,37 @@ class RoutableDataMapperTest extends TestCase
         $this->assertSame([], $localizedDimensionContent->getTemplateData());
     }
 
+    public function testMapNoResourceId(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Expected a LocalizedDimensionContent with a resourceId.');
+
+        $data = [
+            'template' => 'default',
+            'url' => '/test',
+        ];
+
+        $example = new Example();
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $unlocalizedDimensionContent->setStage('live');
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setStage('live');
+        $localizedDimensionContent->setLocale('en');
+
+        $this->structureMetadataFactory->getStructureMetadata('example', 'default')
+            ->shouldBeCalled()
+            ->willReturn($this->createRouteStructureMetadata());
+
+        $this->routeManager->createOrUpdateByAttributes(Argument::cetera())->shouldNotBeCalled();
+        $this->routeGenerator->generate(Argument::cetera())
+            ->shouldNotBeCalled();
+
+        $mapper = $this->createRouteDataMapperInstance();
+        $mapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertSame([], $localizedDimensionContent->getTemplateData());
+    }
+
     public function testMapRouteProperty(): void
     {
         $data = [
@@ -323,7 +326,9 @@ class RoutableDataMapperTest extends TestCase
         $example = new Example();
         static::setPrivateProperty($example, 'id', 1);
         $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $unlocalizedDimensionContent->setStage('live');
         $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setStage('live');
         $localizedDimensionContent->setLocale('en');
 
         $this->structureMetadataFactory->getStructureMetadata('example', 'default')
@@ -351,6 +356,36 @@ class RoutableDataMapperTest extends TestCase
         ], $localizedDimensionContent->getTemplateData());
     }
 
+    public function testMapRouteDraftDimension(): void
+    {
+        $data = [
+            'template' => 'default',
+            'url' => '/test',
+        ];
+
+        $example = new Example();
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setLocale('en');
+
+        $this->structureMetadataFactory->getStructureMetadata('example', 'default')
+            ->shouldBeCalled()
+            ->willReturn($this->createRouteStructureMetadata());
+
+        $this->routeManager->createOrUpdateByAttributes(Argument::cetera())
+            ->shouldNotBeCalled();
+
+        $this->routeGenerator->generate(Argument::cetera())
+            ->shouldNotBeCalled();
+
+        $mapper = $this->createRouteDataMapperInstance();
+        $mapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertSame([
+            'url' => '/test',
+        ], $localizedDimensionContent->getTemplateData());
+    }
+
     public function testMapNoNewAndOldUrl(): void
     {
         $data = [
@@ -363,7 +398,9 @@ class RoutableDataMapperTest extends TestCase
         $example = new Example();
         static::setPrivateProperty($example, 'id', 1);
         $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $unlocalizedDimensionContent->setStage('live');
         $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setStage('live');
         $localizedDimensionContent->setLocale('en');
 
         $this->structureMetadataFactory->getStructureMetadata('example', 'default')
@@ -402,7 +439,9 @@ class RoutableDataMapperTest extends TestCase
         $example = new Example();
         static::setPrivateProperty($example, 'id', 1);
         $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $unlocalizedDimensionContent->setStage('live');
         $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setStage('live');
         $localizedDimensionContent->setLocale('en');
         $localizedDimensionContent->setTemplateData(['url' => '/example']);
 
@@ -437,7 +476,9 @@ class RoutableDataMapperTest extends TestCase
         $example = new Example();
         static::setPrivateProperty($example, 'id', 123);
         $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $unlocalizedDimensionContent->setStage('live');
         $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setStage('live');
         $localizedDimensionContent->setLocale('en');
         $localizedDimensionContent->setTemplateData(['title' => 'Test', 'url' => null]);
 
@@ -450,7 +491,7 @@ class RoutableDataMapperTest extends TestCase
                 '_unlocalizedObject' => $unlocalizedDimensionContent,
                 '_localizedObject' => $localizedDimensionContent,
             ]),
-            ['route_schema' => 'custom/{object["_localizedObject"].getName()}-{object["_unlocalizedObject"].getResourceId()}']
+            ['route_schema' => 'custom/{object["_localizedObject"].getTitle()}-{object["_unlocalizedObject"].getResourceId()}']
         )->willReturn('/custom/testEntity-123');
 
         $this->routeManager->createOrUpdateByAttributes(
@@ -467,7 +508,7 @@ class RoutableDataMapperTest extends TestCase
             'examples' => [
                 'generator' => 'schema',
                 'options' => [
-                    'route_schema' => 'custom/{object["_localizedObject"].getName()}-{object["_unlocalizedObject"].getResourceId()}',
+                    'route_schema' => 'custom/{object["_localizedObject"].getTitle()}-{object["_unlocalizedObject"].getResourceId()}',
                 ],
                 'resource_key' => 'examples',
                 'entityClass' => Example::class,
@@ -476,8 +517,8 @@ class RoutableDataMapperTest extends TestCase
         $mapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
 
         $this->assertSame([
-            'url' => '/custom/testEntity-123',
             'title' => 'Test',
+            'url' => '/custom/testEntity-123',
         ], $localizedDimensionContent->getTemplateData());
     }
 
@@ -528,7 +569,9 @@ class RoutableDataMapperTest extends TestCase
         $example = new Example();
         static::setPrivateProperty($example, 'id', 1);
         $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $unlocalizedDimensionContent->setStage('live');
         $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setStage('live');
         $localizedDimensionContent->setLocale('en');
 
         $this->structureMetadataFactory->getStructureMetadata('example', 'new-default')

--- a/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapperTest.php
+++ b/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapperTest.php
@@ -282,6 +282,9 @@ class RoutableDataMapperTest extends TestCase
 
     public function testMapNoRouteMapping(): void
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('No route mapping found for "examples".');
+
         $data = [
             'template' => 'default',
             'url' => '/test',

--- a/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapperTest.php
+++ b/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapperTest.php
@@ -17,144 +17,94 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMapper\RoutableDataMapper;
-use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\RoutableInterface;
-use Sulu\Bundle\ContentBundle\Content\Domain\Model\TemplateInterface;
-use Sulu\Bundle\ContentBundle\Tests\Unit\Mocks\DimensionContentMockWrapperTrait;
-use Sulu\Bundle\ContentBundle\Tests\Unit\Mocks\MockWrapper;
-use Sulu\Bundle\ContentBundle\Tests\Unit\Mocks\RoutableMockWrapperTrait;
-use Sulu\Bundle\ContentBundle\Tests\Unit\Mocks\TemplateMockWrapperTrait;
+use Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\Example;
+use Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
+use Sulu\Bundle\ContentBundle\Tests\Traits\SetGetPrivatePropertyTrait;
+use Sulu\Bundle\RouteBundle\Entity\Route;
 use Sulu\Bundle\RouteBundle\Generator\RouteGeneratorInterface;
-use Sulu\Bundle\RouteBundle\Manager\ConflictResolverInterface;
 use Sulu\Bundle\RouteBundle\Manager\RouteManagerInterface;
-use Sulu\Bundle\RouteBundle\Model\RouteInterface;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
 use Sulu\Component\Content\Metadata\PropertyMetadata;
 use Sulu\Component\Content\Metadata\StructureMetadata;
 
 class RoutableDataMapperTest extends TestCase
 {
+    use SetGetPrivatePropertyTrait;
+
+    /**
+     * @var ObjectProphecy|StructureMetadataFactoryInterface
+     */
+    private $structureMetadataFactory;
+
+    /**
+     * @var ObjectProphecy|RouteGeneratorInterface
+     */
+    private $routeGenerator;
+
+    /**
+     * @var ObjectProphecy|RouteManagerInterface
+     */
+    private $routeManager;
+
+    protected function setUp(): void
+    {
+        $this->structureMetadataFactory = $this->prophesize(StructureMetadataFactoryInterface::class);
+        $this->routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
+        $this->routeManager = $this->prophesize(RouteManagerInterface::class);
+    }
+
     /**
      * @param array<string, string> $structureDefaultTypes
      * @param array<string, array<mixed>> $resourceKeyMappings
      */
     protected function createRouteDataMapperInstance(
-        StructureMetadataFactoryInterface $factory,
-        RouteGeneratorInterface $routeGenerator,
-        RouteManagerInterface $routeManager,
-        ConflictResolverInterface $conflictResolver,
         array $structureDefaultTypes = [],
-        array $resourceKeyMappings = []
+        ?array $resourceKeyMappings = null
     ): RoutableDataMapper {
-        if (empty($resourceKeyMappings)) {
+        if (!\is_array($resourceKeyMappings)) {
             $resourceKeyMappings = [
-                'mock-resource-key' => [
+                'examples' => [
                     'generator' => 'schema',
                     'options' => [
                         'route_schema' => '/{object["title"]}',
                     ],
-                    'resource_key' => 'mock-resource-key',
-                    'entityClass' => 'mock-content-class',
+                    'resource_key' => 'examples',
+                    'entityClass' => Example::class,
                 ],
             ];
         }
 
-        return new RoutableDataMapper($factory, $routeGenerator, $routeManager, $conflictResolver, $structureDefaultTypes, $resourceKeyMappings);
+        return new RoutableDataMapper(
+            $this->structureMetadataFactory->reveal(),
+            $this->routeGenerator->reveal(),
+            $this->routeManager->reveal(),
+            $structureDefaultTypes,
+            $resourceKeyMappings
+        );
     }
 
-    /**
-     * @param ObjectProphecy<DimensionContentInterface> $routableMock
-     */
-    protected function wrapRoutableMock(ObjectProphecy $routableMock): RoutableInterface
-    {
-        return new class($routableMock) extends MockWrapper implements
-            DimensionContentInterface,
-            TemplateInterface,
-            RoutableInterface {
-            use DimensionContentMockWrapperTrait, RoutableMockWrapperTrait {
-                RoutableMockWrapperTrait::getLocale insteadof DimensionContentMockWrapperTrait;
-                RoutableMockWrapperTrait::getResourceKey insteadof DimensionContentMockWrapperTrait;
-            }
-            use TemplateMockWrapperTrait;
-        };
-    }
-
-    public function testMapNoRoutable(): void
+    public function testMapNoRoutableInterface(): void
     {
         $data = [];
 
         $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
         $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
 
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn($localizedDimensionContent);
-
-        $factory = $this->prophesize(StructureMetadataFactoryInterface::class);
-        $routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
-        $routeManager = $this->prophesize(RouteManagerInterface::class);
-        $conflictResolver = $this->prophesize(ConflictResolverInterface::class);
-
-        $factory->getStructureMetadata(Argument::cetera())->shouldNotBeCalled();
-        $routeManager->createOrUpdateByAttributes(Argument::cetera())->shouldNotBeCalled();
-        $conflictResolver->resolve(Argument::cetera())->shouldNotBeCalled();
-
-        $routeGenerator->generate(Argument::cetera())
+        $this->structureMetadataFactory->getStructureMetadata(Argument::cetera())->shouldNotBeCalled();
+        $this->routeManager->createOrUpdateByAttributes(Argument::cetera())->shouldNotBeCalled();
+        $this->routeGenerator->generate(Argument::cetera())
             ->shouldNotBeCalled();
 
-        $mapper = $this->createRouteDataMapperInstance(
-            $factory->reveal(),
-            $routeGenerator->reveal(),
-            $routeManager->reveal(),
-            $conflictResolver->reveal()
-        );
-
-        $mapper->map($data, $dimensionContentCollection->reveal());
-    }
-
-    public function testMapNoLocalizedDimension(): void
-    {
-        $data = [];
-
-        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn(null);
-
-        $factory = $this->prophesize(StructureMetadataFactoryInterface::class);
-        $routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
-        $routeManager = $this->prophesize(RouteManagerInterface::class);
-        $conflictResolver = $this->prophesize(ConflictResolverInterface::class);
-
-        $factory->getStructureMetadata(Argument::cetera())->shouldNotBeCalled();
-        $routeManager->createOrUpdateByAttributes(Argument::cetera())->shouldNotBeCalled();
-        $conflictResolver->resolve(Argument::cetera())->shouldNotBeCalled();
-
-        $routeGenerator->generate(Argument::cetera())
-            ->shouldNotBeCalled();
-
-        $mapper = $this->createRouteDataMapperInstance(
-            $factory->reveal(),
-            $routeGenerator->reveal(),
-            $routeManager->reveal(),
-            $conflictResolver->reveal()
-        );
-
-        $mapper->map($data, $dimensionContentCollection->reveal());
+        $mapper = $this->createRouteDataMapperInstance();
+        $mapper->map($unlocalizedDimensionContent->reveal(), $localizedDimensionContent->reveal(), $data);
     }
 
     public function testMapNoTemplateInterface(): void
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('LocalizedObject needs to extend the TemplateInterface');
+        $this->expectExceptionMessage('LocalizedDimensionContent needs to extend the TemplateInterface.');
 
         $data = [];
 
@@ -163,76 +113,32 @@ class RoutableDataMapperTest extends TestCase
         $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
         $localizedDimensionContent->willImplement(RoutableInterface::class);
 
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn($localizedDimensionContent);
-
-        $factory = $this->prophesize(StructureMetadataFactoryInterface::class);
-        $routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
-        $routeManager = $this->prophesize(RouteManagerInterface::class);
-        $conflictResolver = $this->prophesize(ConflictResolverInterface::class);
-
-        $factory->getStructureMetadata(Argument::cetera())->shouldNotBeCalled();
-        $routeManager->createOrUpdateByAttributes(Argument::cetera())->shouldNotBeCalled();
-        $conflictResolver->resolve(Argument::cetera())->shouldNotBeCalled();
-        $localizedDimensionContent->getResourceId()->shouldNotBeCalled();
-
-        $routeGenerator->generate(Argument::cetera())
-            ->shouldNotBeCalled();
-
-        $mapper = $this->createRouteDataMapperInstance(
-            $factory->reveal(),
-            $routeGenerator->reveal(),
-            $routeManager->reveal(),
-            $conflictResolver->reveal()
-        );
-
-        $mapper->map($data, $dimensionContentCollection->reveal());
+        $mapper = $this->createRouteDataMapperInstance();
+        $mapper->map($unlocalizedDimensionContent->reveal(), $localizedDimensionContent->reveal(), $data);
     }
 
-    public function testMapNoTemplate(): void
+    public function testMapNoTemplateGiven(): void
     {
         $this->expectException(\RuntimeException::class);
 
         $data = [];
 
-        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent->willImplement(RoutableInterface::class);
-        $localizedDimensionContent->willImplement(TemplateInterface::class);
+        $example = new Example();
+        static::setPrivateProperty($example, 'id', 1);
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setLocale('en');
 
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn($this->wrapRoutableMock($localizedDimensionContent));
-
-        $factory = $this->prophesize(StructureMetadataFactoryInterface::class);
-        $routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
-        $routeManager = $this->prophesize(RouteManagerInterface::class);
-        $conflictResolver = $this->prophesize(ConflictResolverInterface::class);
-
-        $factory->getStructureMetadata(Argument::cetera())->shouldNotBeCalled();
-        $routeManager->createOrUpdateByAttributes(Argument::cetera())->shouldNotBeCalled();
-        $conflictResolver->resolve(Argument::cetera())->shouldNotBeCalled();
-        $localizedDimensionContent->getResourceId()->shouldNotBeCalled();
-        $localizedDimensionContent->setTemplateData(Argument::cetera())->shouldNotBeCalled();
-
-        $routeGenerator->generate(Argument::cetera())
+        $this->structureMetadataFactory->getStructureMetadata(Argument::cetera())->shouldNotBeCalled();
+        $this->routeManager->createOrUpdateByAttributes(Argument::cetera())->shouldNotBeCalled();
+        $this->routeGenerator->generate(Argument::cetera())
             ->shouldNotBeCalled();
 
-        $mapper = $this->createRouteDataMapperInstance(
-            $factory->reveal(),
-            $routeGenerator->reveal(),
-            $routeManager->reveal(),
-            $conflictResolver->reveal()
-        );
+        $mapper = $this->createRouteDataMapperInstance([], []);
 
-        $mapper->map($data, $dimensionContentCollection->reveal());
+        $mapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertSame([], $localizedDimensionContent->getTemplateData());
     }
 
     public function testMapNoMetadata(): void
@@ -241,40 +147,23 @@ class RoutableDataMapperTest extends TestCase
             'template' => 'default',
         ];
 
-        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent->willImplement(RoutableInterface::class);
-        $localizedDimensionContent->willImplement(TemplateInterface::class);
+        $example = new Example();
+        static::setPrivateProperty($example, 'id', 1);
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setLocale('en');
 
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn($this->wrapRoutableMock($localizedDimensionContent));
-
-        $factory = $this->prophesize(StructureMetadataFactoryInterface::class);
-        $routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
-        $routeManager = $this->prophesize(RouteManagerInterface::class);
-        $conflictResolver = $this->prophesize(ConflictResolverInterface::class);
-
-        $routeManager->createOrUpdateByAttributes(Argument::cetera())->shouldNotBeCalled();
-        $conflictResolver->resolve(Argument::cetera())->shouldNotBeCalled();
-        $localizedDimensionContent->setTemplateData(Argument::cetera())->shouldNotBeCalled();
-
-        $factory->getStructureMetadata('mock-template-type', 'default')->willReturn(null)->shouldBeCalled();
-
-        $routeGenerator->generate(Argument::cetera())
+        $this->structureMetadataFactory->getStructureMetadata('example', 'default')
+            ->shouldBeCalled()
+            ->willReturn(null);
+        $this->routeManager->createOrUpdateByAttributes(Argument::cetera())->shouldNotBeCalled();
+        $this->routeGenerator->generate(Argument::cetera())
             ->shouldNotBeCalled();
 
-        $mapper = $this->createRouteDataMapperInstance(
-            $factory->reveal(),
-            $routeGenerator->reveal(),
-            $routeManager->reveal(),
-            $conflictResolver->reveal()
-        );
+        $mapper = $this->createRouteDataMapperInstance();
+        $mapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
 
-        $mapper->map($data, $dimensionContentCollection->reveal());
+        $this->assertSame([], $localizedDimensionContent->getTemplateData());
     }
 
     public function testMapNoRouteProperty(): void
@@ -283,515 +172,345 @@ class RoutableDataMapperTest extends TestCase
             'template' => 'default',
         ];
 
-        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent->willImplement(RoutableInterface::class);
-        $localizedDimensionContent->willImplement(TemplateInterface::class);
+        $example = new Example();
+        static::setPrivateProperty($example, 'id', 1);
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setLocale('en');
 
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn($this->wrapRoutableMock($localizedDimensionContent));
+        $this->structureMetadataFactory->getStructureMetadata('example', 'default')
+            ->shouldBeCalled()
+            ->willReturn($this->createTextLineStructureMetadata());
 
-        $factory = $this->prophesize(StructureMetadataFactoryInterface::class);
-        $routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
-        $routeManager = $this->prophesize(RouteManagerInterface::class);
-        $conflictResolver = $this->prophesize(ConflictResolverInterface::class);
-
-        $routeManager->createOrUpdateByAttributes(Argument::cetera())->shouldNotBeCalled();
-        $conflictResolver->resolve(Argument::cetera())->shouldNotBeCalled();
-        $localizedDimensionContent->setTemplateData(Argument::cetera())->shouldNotBeCalled();
-
-        $metadata = $this->prophesize(StructureMetadata::class);
-        $property = $this->prophesize(PropertyMetadata::class);
-        $property->getType()->willReturn('text_line');
-        $property->getName()->willReturn('url');
-
-        $metadata->getProperties()->WillReturn([$property->reveal()]);
-
-        $localizedDimensionContent->getResourceId()->willReturn('123-123-123');
-        $localizedDimensionContent->getLocale()->willReturn('de');
-        $factory->getStructureMetadata('mock-template-type', 'default')->willReturn($metadata->reveal())->shouldBeCalled();
-
-        $routeGenerator->generate(Argument::cetera())
+        $this->routeManager->createOrUpdateByAttributes(Argument::cetera())->shouldNotBeCalled();
+        $this->routeGenerator->generate(Argument::cetera())
             ->shouldNotBeCalled();
 
-        $mapper = $this->createRouteDataMapperInstance(
-            $factory->reveal(),
-            $routeGenerator->reveal(),
-            $routeManager->reveal(),
-            $conflictResolver->reveal()
-        );
+        $mapper = $this->createRouteDataMapperInstance();
+        $mapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
 
-        $mapper->map($data, $dimensionContentCollection->reveal());
-    }
-
-    public function testMapNoRoutePropertyData(): void
-    {
-        $data = [
-            'template' => 'default',
-        ];
-
-        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent->willImplement(RoutableInterface::class);
-        $localizedDimensionContent->willImplement(TemplateInterface::class);
-
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn($this->wrapRoutableMock($localizedDimensionContent));
-
-        $factory = $this->prophesize(StructureMetadataFactoryInterface::class);
-        $routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
-        $routeManager = $this->prophesize(RouteManagerInterface::class);
-        $conflictResolver = $this->prophesize(ConflictResolverInterface::class);
-
-        $routeManager->createOrUpdateByAttributes(Argument::cetera())->shouldNotBeCalled();
-        $conflictResolver->resolve(Argument::cetera())->shouldNotBeCalled();
-        $localizedDimensionContent->setTemplateData(Argument::cetera())->shouldNotBeCalled();
-
-        $metadata = $this->prophesize(StructureMetadata::class);
-        $property = $this->prophesize(PropertyMetadata::class);
-        $property->getType()->willReturn('route');
-        $property->getName()->willReturn('url');
-
-        $metadata->getProperties()->WillReturn([$property->reveal()]);
-
-        $localizedDimensionContent->getResourceId()->willReturn('123-123-123');
-        $localizedDimensionContent->getTemplateData()->willReturn(['url' => '/test']);
-        $localizedDimensionContent->getLocale()->willReturn('de');
-        $factory->getStructureMetadata('mock-template-type', 'default')->willReturn($metadata->reveal())->shouldBeCalled();
-
-        $routeGenerator->generate(Argument::cetera())
-            ->shouldNotBeCalled();
-
-        $mapper = $this->createRouteDataMapperInstance(
-            $factory->reveal(),
-            $routeGenerator->reveal(),
-            $routeManager->reveal(),
-            $conflictResolver->reveal()
-        );
-
-        $mapper->map($data, $dimensionContentCollection->reveal());
-    }
-
-    public function testMapNoRoutePropertyDataAndNoOldRoute(): void
-    {
-        $data = [
-            'template' => 'default',
-        ];
-
-        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent->willImplement(RoutableInterface::class);
-        $localizedDimensionContent->willImplement(TemplateInterface::class);
-        $localizedDimensionContentMock = $this->wrapRoutableMock($localizedDimensionContent);
-
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn($localizedDimensionContentMock);
-
-        $factory = $this->prophesize(StructureMetadataFactoryInterface::class);
-        $routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
-        $routeManager = $this->prophesize(RouteManagerInterface::class);
-        $conflictResolver = $this->prophesize(ConflictResolverInterface::class);
-
-        $metadata = $this->prophesize(StructureMetadata::class);
-        $property = $this->prophesize(PropertyMetadata::class);
-        $property->getType()->willReturn('route');
-        $property->getName()->willReturn('url');
-
-        $metadata->getProperties()->WillReturn([$property->reveal()]);
-
-        $localizedDimensionContent->getResourceId()->willReturn('123-123-123');
-        $localizedDimensionContent->getTemplateData()->willReturn([]);
-        $localizedDimensionContent->getLocale()->willReturn('en');
-        $localizedDimensionContent->setTemplateData(['url' => '/test'])->shouldBeCalled();
-
-        $factory->getStructureMetadata('mock-template-type', 'default')->willReturn($metadata->reveal())->shouldBeCalled();
-
-        $routeGenerator->generate(
-            \array_merge($data, [
-                '_unlocalizedObject' => $unlocalizedDimensionContent->reveal(),
-                '_localizedObject' => $localizedDimensionContentMock,
-            ]),
-            ['route_schema' => '/{object["title"]}']
-        )->willReturn('/test');
-
-        $route = $this->prophesize(RouteInterface::class);
-        $route->getPath()->willReturn('/test');
-        $routeManager->createOrUpdateByAttributes(
-            'mock-content-class',
-            '123-123-123',
-            'en',
-            '/test'
-        )->willReturn($route->reveal());
-
-        $conflictResolver->resolve($route->reveal())->shouldBeCalled();
-        $localizedDimensionContent->setTemplateData(['url' => '/test'])->shouldBeCalled();
-
-        $mapper = $this->createRouteDataMapperInstance(
-            $factory->reveal(),
-            $routeGenerator->reveal(),
-            $routeManager->reveal(),
-            $conflictResolver->reveal()
-        );
-
-        $mapper->map($data, $dimensionContentCollection->reveal());
-    }
-
-    public function testMapNoRoutePropertyDataAndNoOldRouteIgnoreSlash(): void
-    {
-        $data = [
-            'template' => 'default',
-        ];
-
-        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent->willImplement(RoutableInterface::class);
-        $localizedDimensionContent->willImplement(TemplateInterface::class);
-        $localizedDimensionContentMock = $this->wrapRoutableMock($localizedDimensionContent);
-
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn($localizedDimensionContentMock);
-
-        $factory = $this->prophesize(StructureMetadataFactoryInterface::class);
-        $routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
-        $routeManager = $this->prophesize(RouteManagerInterface::class);
-        $conflictResolver = $this->prophesize(ConflictResolverInterface::class);
-
-        $metadata = $this->prophesize(StructureMetadata::class);
-        $property = $this->prophesize(PropertyMetadata::class);
-        $property->getType()->willReturn('route');
-        $property->getName()->willReturn('url');
-
-        $metadata->getProperties()->WillReturn([$property->reveal()]);
-
-        $localizedDimensionContent->getResourceId()->willReturn('123-123-123');
-        $localizedDimensionContent->getTemplateData()->willReturn([]);
-        $localizedDimensionContent->getLocale()->willReturn('en');
-        $localizedDimensionContent->setTemplateData(Argument::cetera())->shouldNotBeCalled();
-
-        $factory->getStructureMetadata('mock-template-type', 'default')->willReturn($metadata->reveal())->shouldBeCalled();
-
-        $routeGenerator->generate(
-            \array_merge($data, [
-                '_unlocalizedObject' => $unlocalizedDimensionContent->reveal(),
-                '_localizedObject' => $localizedDimensionContentMock,
-            ]),
-            ['route_schema' => '/{object["title"]}']
-        )->willReturn('/');
-
-        $routeManager->createOrUpdateByAttributes(Argument::cetera())->shouldNotBeCalled();
-        $conflictResolver->resolve(Argument::cetera())->shouldNotBeCalled();
-        $localizedDimensionContent->setTemplateData(Argument::cetera())->shouldNotBeCalled();
-
-        $mapper = $this->createRouteDataMapperInstance(
-            $factory->reveal(),
-            $routeGenerator->reveal(),
-            $routeManager->reveal(),
-            $conflictResolver->reveal()
-        );
-
-        $mapper->map($data, $dimensionContentCollection->reveal());
-    }
-
-    public function testMapNoContentId(): void
-    {
-        $data = [
-            'template' => 'default',
-        ];
-
-        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent->willImplement(RoutableInterface::class);
-        $localizedDimensionContent->willImplement(TemplateInterface::class);
-
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn($this->wrapRoutableMock($localizedDimensionContent));
-
-        $factory = $this->prophesize(StructureMetadataFactoryInterface::class);
-        $routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
-        $routeManager = $this->prophesize(RouteManagerInterface::class);
-        $conflictResolver = $this->prophesize(ConflictResolverInterface::class);
-
-        $routeManager->createOrUpdateByAttributes(Argument::cetera())->shouldNotBeCalled();
-        $conflictResolver->resolve(Argument::cetera())->shouldNotBeCalled();
-        $localizedDimensionContent->setTemplateData(Argument::cetera())->shouldNotBeCalled();
-
-        $metadata = $this->prophesize(StructureMetadata::class);
-        $property = $this->prophesize(PropertyMetadata::class);
-        $property->getType()->willReturn('route');
-
-        $metadata->getProperties()->WillReturn([$property->reveal()]);
-
-        $factory->getStructureMetadata('mock-template-type', 'default')->willReturn($metadata->reveal())->shouldBeCalled();
-
-        $localizedDimensionContent->getResourceId()->willReturn(null);
-
-        $mapper = $this->createRouteDataMapperInstance(
-            $factory->reveal(),
-            $routeGenerator->reveal(),
-            $routeManager->reveal(),
-            $conflictResolver->reveal()
-        );
-
-        $mapper->map($data, $dimensionContentCollection->reveal());
+        $this->assertSame([], $localizedDimensionContent->getTemplateData());
     }
 
     public function testMapNoLocale(): void
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Expected a LocalizedDimensionContent with a locale.');
+
         $data = [
             'template' => 'default',
         ];
 
-        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent->willImplement(RoutableInterface::class);
-        $localizedDimensionContent->willImplement(TemplateInterface::class);
+        $example = new Example();
+        static::setPrivateProperty($example, 'id', 1);
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
 
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn($this->wrapRoutableMock($localizedDimensionContent));
+        $this->structureMetadataFactory->getStructureMetadata('example', 'default')
+            ->shouldBeCalled()
+            ->willReturn($this->createRouteStructureMetadata());
 
-        $factory = $this->prophesize(StructureMetadataFactoryInterface::class);
-        $routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
-        $routeManager = $this->prophesize(RouteManagerInterface::class);
-        $conflictResolver = $this->prophesize(ConflictResolverInterface::class);
+        $this->routeManager->createOrUpdateByAttributes(Argument::cetera())->shouldNotBeCalled();
+        $this->routeGenerator->generate(Argument::cetera())
+            ->shouldNotBeCalled();
 
-        $routeManager->createOrUpdateByAttributes(Argument::cetera())->shouldNotBeCalled();
-        $conflictResolver->resolve(Argument::cetera())->shouldNotBeCalled();
-        $localizedDimensionContent->setTemplateData(Argument::cetera())->shouldNotBeCalled();
+        $mapper = $this->createRouteDataMapperInstance();
+        $mapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
 
-        $metadata = $this->prophesize(StructureMetadata::class);
-        $property = $this->prophesize(PropertyMetadata::class);
-        $property->getType()->willReturn('route');
-
-        $metadata->getProperties()->WillReturn([$property->reveal()]);
-
-        $factory->getStructureMetadata('mock-template-type', 'default')->willReturn($metadata->reveal())->shouldBeCalled();
-
-        $localizedDimensionContent->getResourceId()->willReturn('123-123-123');
-        $localizedDimensionContent->getLocale()->willReturn(null);
-
-        $mapper = $this->createRouteDataMapperInstance(
-            $factory->reveal(),
-            $routeGenerator->reveal(),
-            $routeManager->reveal(),
-            $conflictResolver->reveal()
-        );
-
-        $mapper->map($data, $dimensionContentCollection->reveal());
+        $this->assertSame([], $localizedDimensionContent->getTemplateData());
     }
 
-    public function testMapNoRoutePath(): void
+    public function testMapNoResourceId(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Expected a LocalizedDimensionContent with a resourceId.');
+
+        $data = [
+            'template' => 'default',
+        ];
+
+        $example = new Example();
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setLocale('en');
+
+        $this->structureMetadataFactory->getStructureMetadata('example', 'default')
+            ->shouldBeCalled()
+            ->willReturn($this->createRouteStructureMetadata());
+
+        $this->routeManager->createOrUpdateByAttributes(Argument::cetera())->shouldNotBeCalled();
+        $this->routeGenerator->generate(Argument::cetera())
+            ->shouldNotBeCalled();
+
+        $mapper = $this->createRouteDataMapperInstance();
+        $mapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertSame([], $localizedDimensionContent->getTemplateData());
+    }
+
+    public function testMapNoRoutePropertyValue(): void
+    {
+        // see https://github.com/sulu/SuluContentBundle/pull/55
+        $this->markTestSkipped(
+            'This is currently handled the same way as "testMapNoNewAndOldUrl". But should be handle differently to avoid patch creates.'
+        );
+
+        /** @phpstan-ignore-next-line */
+        $data = [
+            'template' => 'default',
+        ];
+
+        $example = new Example();
+        static::setPrivateProperty($example, 'id', 1);
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setLocale('en');
+
+        $this->structureMetadataFactory->getStructureMetadata('example', 'default')
+            ->shouldBeCalled()
+            ->willReturn($this->createRouteStructureMetadata());
+
+        $this->routeManager->createOrUpdateByAttributes(Argument::cetera())->shouldNotBeCalled();
+        $this->routeGenerator->generate(Argument::cetera())
+            ->shouldNotBeCalled();
+
+        $mapper = $this->createRouteDataMapperInstance();
+        $mapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertSame([], $localizedDimensionContent->getTemplateData());
+    }
+
+    public function testMapNoRouteMapping(): void
+    {
+        $data = [
+            'template' => 'default',
+            'url' => '/test',
+        ];
+
+        $example = new Example();
+        static::setPrivateProperty($example, 'id', 1);
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setLocale('en');
+
+        $this->structureMetadataFactory->getStructureMetadata('example', 'default')
+            ->shouldBeCalled()
+            ->willReturn($this->createRouteStructureMetadata());
+
+        $this->routeManager->createOrUpdateByAttributes(Argument::cetera())->shouldNotBeCalled();
+        $this->routeGenerator->generate(Argument::cetera())
+            ->shouldNotBeCalled();
+
+        $mapper = $this->createRouteDataMapperInstance([], []);
+        $mapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertSame([], $localizedDimensionContent->getTemplateData());
+    }
+
+    public function testMapRouteProperty(): void
+    {
+        $data = [
+            'template' => 'default',
+            'url' => '/test',
+        ];
+
+        $route = new Route();
+        $route->setPath('/test-1');
+
+        $example = new Example();
+        static::setPrivateProperty($example, 'id', 1);
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setLocale('en');
+
+        $this->structureMetadataFactory->getStructureMetadata('example', 'default')
+            ->shouldBeCalled()
+            ->willReturn($this->createRouteStructureMetadata());
+
+        $this->routeManager->createOrUpdateByAttributes(
+            Example::class,
+            '1',
+            'en',
+            '/test',
+            true
+        )
+            ->shouldBeCalled()
+            ->willReturn($route);
+
+        $this->routeGenerator->generate(Argument::cetera())
+            ->shouldNotBeCalled();
+
+        $mapper = $this->createRouteDataMapperInstance();
+        $mapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertSame([
+            'url' => '/test-1',
+        ], $localizedDimensionContent->getTemplateData());
+    }
+
+    public function testMapNoNewAndOldUrl(): void
+    {
+        $data = [
+            'template' => 'default',
+        ];
+
+        $route = new Route();
+        $route->setPath('/test');
+
+        $example = new Example();
+        static::setPrivateProperty($example, 'id', 1);
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setLocale('en');
+
+        $this->structureMetadataFactory->getStructureMetadata('example', 'default')
+            ->shouldBeCalled()
+            ->willReturn($this->createRouteStructureMetadata());
+
+        $this->routeGenerator->generate(Argument::cetera())->willReturn('/test');
+
+        $this->routeManager->createOrUpdateByAttributes(
+            Example::class,
+            '1',
+            'en',
+            '/test',
+            true
+        )
+            ->shouldBeCalled()
+            ->willReturn($route);
+
+        $mapper = $this->createRouteDataMapperInstance();
+        $mapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertSame([
+            'url' => '/test',
+        ], $localizedDimensionContent->getTemplateData());
+    }
+
+    public function testMapWithNoUrlButOldUrl(): void
+    {
+        $data = [
+            'template' => 'default',
+        ];
+
+        $route = new Route();
+        $route->setPath('/test-1');
+
+        $example = new Example();
+        static::setPrivateProperty($example, 'id', 1);
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setLocale('en');
+        $localizedDimensionContent->setTemplateData(['url' => '/example']);
+
+        $this->structureMetadataFactory->getStructureMetadata('example', 'default')
+            ->shouldBeCalled()
+            ->willReturn($this->createRouteStructureMetadata());
+
+        $this->routeManager->createOrUpdateByAttributes(Argument::cetera())
+            ->shouldNotBeCalled();
+
+        $this->routeGenerator->generate(Argument::cetera())
+            ->shouldNotBeCalled();
+
+        $mapper = $this->createRouteDataMapperInstance();
+        $mapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertSame([
+            'url' => '/example',
+        ], $localizedDimensionContent->getTemplateData());
+    }
+
+    public function testMapGenerate(): void
     {
         $data = [
             'template' => 'default',
             'url' => null,
         ];
 
-        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent->willImplement(RoutableInterface::class);
-        $localizedDimensionContent->willImplement(TemplateInterface::class);
-        $localizedDimensionContentMock = $this->wrapRoutableMock($localizedDimensionContent);
+        $route = new Route();
+        $route->setPath('/custom/testEntity-123');
 
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn($localizedDimensionContentMock);
+        $example = new Example();
+        static::setPrivateProperty($example, 'id', 123);
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setLocale('en');
+        $localizedDimensionContent->setTemplateData(['title' => 'Test', 'url' => null]);
 
-        $factory = $this->prophesize(StructureMetadataFactoryInterface::class);
-        $routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
-        $routeManager = $this->prophesize(RouteManagerInterface::class);
-        $conflictResolver = $this->prophesize(ConflictResolverInterface::class);
+        $this->structureMetadataFactory->getStructureMetadata('example', 'default')
+            ->shouldBeCalled()
+            ->willReturn($this->createRouteStructureMetadata());
 
-        $metadata = $this->prophesize(StructureMetadata::class);
-        $property = $this->prophesize(PropertyMetadata::class);
-        $property->getType()->willReturn('route');
-        $property->getName()->willReturn('url');
-
-        $metadata->getProperties()->WillReturn([$property->reveal()]);
-
-        $factory->getStructureMetadata('mock-template-type', 'default')->willReturn($metadata->reveal())->shouldBeCalled();
-
-        $localizedDimensionContent->getResourceId()->willReturn('123-123-123');
-        $localizedDimensionContent->getTemplateData()->willReturn(['title' => 'Test', 'url' => null]);
-        $localizedDimensionContent->getLocale()->willReturn('en');
-
-        $routeGenerator->generate(
+        $this->routeGenerator->generate(
             \array_merge($data, [
-                '_unlocalizedObject' => $unlocalizedDimensionContent->reveal(),
-                '_localizedObject' => $localizedDimensionContentMock,
+                '_unlocalizedObject' => $unlocalizedDimensionContent,
+                '_localizedObject' => $localizedDimensionContent,
             ]),
-            ['route_schema' => '/{object["title"]}']
-        )->willReturn('/test');
+            ['route_schema' => 'custom/{object["_localizedObject"].getName()}-{object["_unlocalizedObject"].getResourceId()}']
+        )->willReturn('/custom/testEntity-123');
 
-        $route = $this->prophesize(RouteInterface::class);
-        $route->getPath()->willReturn('/test');
-        $routeManager->createOrUpdateByAttributes(
-            'mock-content-class',
-            '123-123-123',
+        $this->routeManager->createOrUpdateByAttributes(
+            Example::class,
+            '123',
             'en',
-            '/test'
-        )->willReturn($route->reveal());
+            '/custom/testEntity-123',
+            true
+        )
+            ->shouldBeCalled()
+            ->willReturn($route);
 
-        $conflictResolver->resolve($route->reveal())->shouldBeCalled();
-        $localizedDimensionContent->setTemplateData(['title' => 'Test', 'url' => '/test'])->shouldBeCalled();
+        $mapper = $this->createRouteDataMapperInstance([], [
+            'examples' => [
+                'generator' => 'schema',
+                'options' => [
+                    'route_schema' => 'custom/{object["_localizedObject"].getName()}-{object["_unlocalizedObject"].getResourceId()}',
+                ],
+                'resource_key' => 'examples',
+                'entityClass' => Example::class,
+            ],
+        ]);
+        $mapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
 
-        $mapper = $this->createRouteDataMapperInstance(
-            $factory->reveal(),
-            $routeGenerator->reveal(),
-            $routeManager->reveal(),
-            $conflictResolver->reveal()
-        );
-
-        $mapper->map($data, $dimensionContentCollection->reveal());
+        $this->assertSame([
+            'url' => '/custom/testEntity-123',
+            'title' => 'Test',
+        ], $localizedDimensionContent->getTemplateData());
     }
 
-    public function testMap(): void
+    public function testMapOnlySlash(): void
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not allowed url "/" given or generated.');
+
         $data = [
             'template' => 'default',
-            'url' => '/test',
+            'url' => null,
         ];
 
-        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent->willImplement(RoutableInterface::class);
-        $localizedDimensionContent->willImplement(TemplateInterface::class);
+        $route = new Route();
+        $route->setPath('/custom/testEntity-123');
 
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn($this->wrapRoutableMock($localizedDimensionContent));
+        $example = new Example();
+        static::setPrivateProperty($example, 'id', 123);
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setLocale('en');
+        $localizedDimensionContent->setTemplateData(['title' => 'Test', 'url' => null]);
 
-        $factory = $this->prophesize(StructureMetadataFactoryInterface::class);
-        $routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
-        $routeManager = $this->prophesize(RouteManagerInterface::class);
-        $conflictResolver = $this->prophesize(ConflictResolverInterface::class);
+        $this->structureMetadataFactory->getStructureMetadata('example', 'default')
+            ->shouldBeCalled()
+            ->willReturn($this->createRouteStructureMetadata());
 
-        $metadata = $this->prophesize(StructureMetadata::class);
-        $property = $this->prophesize(PropertyMetadata::class);
-        $property->getType()->willReturn('route');
-        $property->getName()->willReturn('url');
+        $this->routeGenerator->generate(Argument::cetera())->willReturn('/');
 
-        $metadata->getProperties()->WillReturn([$property->reveal()]);
+        $mapper = $this->createRouteDataMapperInstance();
+        $mapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
 
-        $localizedDimensionContent->getTemplateData()->willReturn([]);
-        $factory->getStructureMetadata('mock-template-type', 'default')->willReturn($metadata->reveal())->shouldBeCalled();
-
-        $localizedDimensionContent->getResourceId()->willReturn('123-123-123');
-        $localizedDimensionContent->getLocale()->willReturn('en');
-
-        $routeGenerator->generate(Argument::any())->shouldNotBeCalled();
-
-        $route = $this->prophesize(RouteInterface::class);
-        $route->getPath()->willReturn('/test');
-        $routeManager->createOrUpdateByAttributes(
-            'mock-content-class',
-            '123-123-123',
-            'en',
-            '/test'
-        )->willReturn($route->reveal());
-
-        $conflictResolver->resolve($route->reveal())->shouldBeCalled();
-        $localizedDimensionContent->setTemplateData(Argument::cetera())->shouldNotBeCalled();
-
-        $mapper = $this->createRouteDataMapperInstance(
-            $factory->reveal(),
-            $routeGenerator->reveal(),
-            $routeManager->reveal(),
-            $conflictResolver->reveal()
-        );
-
-        $mapper->map($data, $dimensionContentCollection->reveal());
-    }
-
-    public function testMapConflictingRoute(): void
-    {
-        $data = [
-            'template' => 'default',
-            'url' => '/test',
-        ];
-
-        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent->willImplement(RoutableInterface::class);
-        $localizedDimensionContent->willImplement(TemplateInterface::class);
-
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn($this->wrapRoutableMock($localizedDimensionContent));
-
-        $factory = $this->prophesize(StructureMetadataFactoryInterface::class);
-        $routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
-        $routeManager = $this->prophesize(RouteManagerInterface::class);
-        $conflictResolver = $this->prophesize(ConflictResolverInterface::class);
-
-        $metadata = $this->prophesize(StructureMetadata::class);
-        $property = $this->prophesize(PropertyMetadata::class);
-        $property->getType()->willReturn('route');
-        $property->getName()->willReturn('url');
-
-        $metadata->getProperties()->WillReturn([$property->reveal()]);
-
-        $localizedDimensionContent->getTemplateData()->willReturn([]);
-        $factory->getStructureMetadata('mock-template-type', 'default')->willReturn($metadata->reveal())->shouldBeCalled();
-
-        $localizedDimensionContent->getResourceId()->willReturn('123-123-123');
-        $localizedDimensionContent->getLocale()->willReturn('en');
-
-        $routeGenerator->generate(Argument::any())->shouldNotBeCalled();
-
-        $route = $this->prophesize(RouteInterface::class);
-        $route->getPath()->willReturn('/test-1');
-
-        $routeManager->createOrUpdateByAttributes(
-            'mock-content-class',
-            '123-123-123',
-            'en',
-            '/test'
-        )->willReturn($route->reveal());
-
-        $conflictResolver->resolve($route->reveal())->shouldBeCalled();
-        $localizedDimensionContent->setTemplateData(['url' => '/test-1'])->shouldBeCalled();
-
-        $mapper = $this->createRouteDataMapperInstance(
-            $factory->reveal(),
-            $routeGenerator->reveal(),
-            $routeManager->reveal(),
-            $conflictResolver->reveal()
-        );
-
-        $mapper->map($data, $dimensionContentCollection->reveal());
+        $this->assertSame([
+            'url' => '/custom/testEntity-123',
+            'title' => 'Test',
+        ], $localizedDimensionContent->getTemplateData());
     }
 
     public function testMapNoTemplateWithDefaultTemplate(): void
@@ -800,137 +519,67 @@ class RoutableDataMapperTest extends TestCase
             'url' => '/test',
         ];
 
-        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent->willImplement(RoutableInterface::class);
-        $localizedDimensionContent->willImplement(TemplateInterface::class);
+        $route = new Route();
+        $route->setPath('/test-1');
 
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn($this->wrapRoutableMock($localizedDimensionContent));
+        $example = new Example();
+        static::setPrivateProperty($example, 'id', 1);
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setLocale('en');
 
-        $factory = $this->prophesize(StructureMetadataFactoryInterface::class);
-        $routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
-        $routeManager = $this->prophesize(RouteManagerInterface::class);
-        $conflictResolver = $this->prophesize(ConflictResolverInterface::class);
+        $this->structureMetadataFactory->getStructureMetadata('example', 'new-default')
+            ->shouldBeCalled()
+            ->willReturn($this->createRouteStructureMetadata());
 
-        $metadata = $this->prophesize(StructureMetadata::class);
-        $property = $this->prophesize(PropertyMetadata::class);
-        $property->getType()->willReturn('route');
-        $property->getName()->willReturn('url');
-
-        $metadata->getProperties()->willReturn([$property->reveal()]);
-
-        $localizedDimensionContent->getTemplateData()->willReturn([]);
-        $factory->getStructureMetadata('mock-template-type', 'default')->willReturn($metadata->reveal())->shouldBeCalled();
-
-        $localizedDimensionContent->getResourceId()->willReturn('123-123-123');
-        $localizedDimensionContent->getLocale()->willReturn('en');
-
-        $routeGenerator->generate(Argument::any())->shouldNotBeCalled();
-
-        $route = $this->prophesize(RouteInterface::class);
-        $route->getPath()->willReturn('/test');
-        $routeManager->createOrUpdateByAttributes(
-            'mock-content-class',
-            '123-123-123',
+        $this->routeManager->createOrUpdateByAttributes(
+            Example::class,
+            '1',
             'en',
-            '/test'
-        )->willReturn($route->reveal());
+            '/test',
+            true
+        )
+            ->shouldBeCalled()
+            ->willReturn($route);
 
-        $conflictResolver->resolve($route->reveal())->shouldBeCalled();
-        $localizedDimensionContent->setTemplateData(Argument::cetera())->shouldNotBeCalled();
+        $this->routeGenerator->generate(Argument::cetera())
+            ->shouldNotBeCalled();
 
-        $mapper = $this->createRouteDataMapperInstance(
-            $factory->reveal(),
-            $routeGenerator->reveal(),
-            $routeManager->reveal(),
-            $conflictResolver->reveal(),
-            ['mock-template-type' => 'default']
-        );
+        $mapper = $this->createRouteDataMapperInstance([
+            'example' => 'new-default',
+        ]);
+        $mapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
 
-        $mapper->map($data, $dimensionContentCollection->reveal());
+        $this->assertSame([
+            'url' => '/test-1',
+        ], $localizedDimensionContent->getTemplateData());
     }
 
-    public function testMapCustomRoute(): void
+    private function createRouteStructureMetadata(): StructureMetadata
     {
-        $data = [
-            'template' => 'default',
-            'url' => null,
-        ];
-
-        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent->willImplement(RoutableInterface::class);
-        $localizedDimensionContent->willImplement(TemplateInterface::class);
-        $localizedDimensionContentMock = $this->wrapRoutableMock($localizedDimensionContent);
-
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn($localizedDimensionContentMock);
-
-        $factory = $this->prophesize(StructureMetadataFactoryInterface::class);
-        $routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
-        $routeManager = $this->prophesize(RouteManagerInterface::class);
-        $conflictResolver = $this->prophesize(ConflictResolverInterface::class);
-
-        $metadata = $this->prophesize(StructureMetadata::class);
         $property = $this->prophesize(PropertyMetadata::class);
         $property->getType()->willReturn('route');
         $property->getName()->willReturn('url');
 
-        $metadata->getProperties()->WillReturn([$property->reveal()]);
+        $structureMetadata = $this->prophesize(StructureMetadata::class);
+        $structureMetadata->getProperties()->willReturn([
+            $property->reveal(),
+        ])->shouldBeCalled();
 
-        $factory->getStructureMetadata('mock-template-type', 'default')->willReturn($metadata->reveal())->shouldBeCalled();
+        return $structureMetadata->reveal();
+    }
 
-        $localizedDimensionContent->getResourceId()->willReturn('123-123-123');
-        $localizedDimensionContent->getTemplateData()->willReturn(['title' => 'Test', 'url' => null]);
-        $localizedDimensionContent->getLocale()->willReturn('en');
+    private function createTextLineStructureMetadata(): StructureMetadata
+    {
+        $property = $this->prophesize(PropertyMetadata::class);
+        $property->getType()->willReturn('text_line');
+        $property->getName()->willReturn('url');
 
-        $routeGenerator->generate(
-            \array_merge($data, [
-                '_unlocalizedObject' => $unlocalizedDimensionContent->reveal(),
-                '_localizedObject' => $localizedDimensionContentMock,
-            ]),
-            ['route_schema' => 'custom/{object["_localizedObject"].getName()}-{object["_unlocalizedObject"].getResourceId()}']
-        )->willReturn('/custom/testEntity-123');
+        $structureMetadata = $this->prophesize(StructureMetadata::class);
+        $structureMetadata->getProperties()->willReturn([
+            $property->reveal(),
+        ])->shouldBeCalled();
 
-        $route = $this->prophesize(RouteInterface::class);
-        $route->getPath()->willReturn('/custom/testEntity-123');
-        $routeManager->createOrUpdateByAttributes(
-            'Sulu/Test/TestEntity',
-            '123-123-123',
-            'en',
-            '/custom/testEntity-123'
-        )->willReturn($route->reveal());
-
-        $conflictResolver->resolve($route->reveal())->shouldBeCalled();
-        $localizedDimensionContent->setTemplateData(['title' => 'Test', 'url' => '/custom/testEntity-123'])->shouldBeCalled();
-
-        $mapper = $this->createRouteDataMapperInstance(
-            $factory->reveal(),
-            $routeGenerator->reveal(),
-            $routeManager->reveal(),
-            $conflictResolver->reveal(),
-            [],
-            [
-                'mock-resource-key' => [
-                    'generator' => 'schema',
-                    'options' => [
-                        'route_schema' => 'custom/{object["_localizedObject"].getName()}-{object["_unlocalizedObject"].getResourceId()}',
-                    ],
-                    'resource_key' => 'mock-resource-key',
-                    'entityClass' => 'Sulu/Test/TestEntity',
-                ],
-            ]
-        );
-
-        $mapper->map($data, $dimensionContentCollection->reveal());
+        return $structureMetadata->reveal();
     }
 }

--- a/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/SeoDataMapperTest.php
+++ b/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/SeoDataMapperTest.php
@@ -15,9 +15,7 @@ namespace Sulu\Bundle\ContentBundle\Tests\Unit\Content\Application\ContentDataMa
 
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMapper\SeoDataMapper;
-use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
-use Sulu\Bundle\ContentBundle\Content\Domain\Model\SeoInterface;
 use Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\Example;
 use Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
 

--- a/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/TemplateDataMapperTest.php
+++ b/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/TemplateDataMapperTest.php
@@ -172,7 +172,7 @@ class TemplateDataMapperTest extends TestCase
         $this->assertNull($unlocalizedDimensionContent->getTemplateKey());
         $this->assertSame('template-key', $localizedDimensionContent->getTemplateKey());
         $this->assertSame(['unlocalizedField' => 'Test Unlocalized'], $unlocalizedDimensionContent->getTemplateData());
-        $this->assertSame(['1.1' => 'Test Float', 'title' => 'Test Localized'], $localizedDimensionContent->getTemplateData());
+        $this->assertSame(['title' => 'Test Localized', '1.1' => 'Test Float'], $localizedDimensionContent->getTemplateData());
     }
 
     public function testMapWithDefaultTemplate(): void

--- a/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/WorkflowDataMapperTest.php
+++ b/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/WorkflowDataMapperTest.php
@@ -14,11 +14,10 @@ declare(strict_types=1);
 namespace Sulu\Bundle\ContentBundle\Tests\Unit\Content\Application\ContentDataMapper\DataMapper;
 
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMapper\WorkflowDataMapper;
-use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
-use Sulu\Bundle\ContentBundle\Content\Domain\Model\WorkflowInterface;
+use Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\Example;
+use Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
 
 class WorkflowDataMapperTest extends TestCase
 {
@@ -27,10 +26,8 @@ class WorkflowDataMapperTest extends TestCase
         return new WorkflowDataMapper();
     }
 
-    public function testMapNoWorkflow(): void
+    public function testMapNoWorkflowInterface(): void
     {
-        $workflowMapper = $this->createWorkflowDataMapperInstance();
-
         $data = [
             'published' => (new \DateTime())->format('c'),
         ];
@@ -38,264 +35,120 @@ class WorkflowDataMapperTest extends TestCase
         $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
         $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
 
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn($localizedDimensionContent);
-
-        $workflowMapper->map($data, $dimensionContentCollection->reveal());
+        $workflowMapper = $this->createWorkflowDataMapperInstance();
+        $workflowMapper->map($unlocalizedDimensionContent->reveal(), $localizedDimensionContent->reveal(), $data);
 
         $this->assertTrue(true); // Avoid risky test as this is an early return test
     }
 
-    public function testMapLocalizedNoWorkflow(): void
+    public function testMapNoData(): void
     {
-        $workflowMapper = $this->createWorkflowDataMapperInstance();
-
-        $data = [
-            'published' => (new \DateTime())->format('c'),
-        ];
-
-        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $unlocalizedDimensionContent->willImplement(WorkflowInterface::class);
-        $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn($localizedDimensionContent);
-
-        $this->expectException(\RuntimeException::class);
-
-        $workflowMapper->map($data, $dimensionContentCollection->reveal());
-    }
-
-    public function testMapUnlocalizedDraft(): void
-    {
-        $workflowMapper = $this->createWorkflowDataMapperInstance();
-
-        $data = [
-            'published' => (new \DateTime())->format('c'),
-        ];
-
-        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $unlocalizedDimensionContent->willImplement(WorkflowInterface::class);
-        $unlocalizedDimensionContent->getStage()->willReturn(DimensionContentInterface::STAGE_DRAFT);
-        $unlocalizedDimensionContent->getWorkflowPlace()->willReturn(null);
-
-        $unlocalizedDimensionContent->setWorkflowPlace(WorkflowInterface::WORKFLOW_PLACE_UNPUBLISHED)->shouldBeCalled();
-        $unlocalizedDimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
-
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn(null);
-
-        $workflowMapper->map($data, $dimensionContentCollection->reveal());
-    }
-
-    public function testMapUnlocalizedDraftPlaceAlreadySet(): void
-    {
-        $workflowMapper = $this->createWorkflowDataMapperInstance();
-
-        $data = [
-            'published' => (new \DateTime())->format('c'),
-        ];
-
-        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $unlocalizedDimensionContent->willImplement(WorkflowInterface::class);
-        $unlocalizedDimensionContent->getStage()->willReturn(DimensionContentInterface::STAGE_DRAFT);
-        $unlocalizedDimensionContent->getWorkflowPlace()->willReturn(WorkflowInterface::WORKFLOW_PLACE_UNPUBLISHED);
-        $unlocalizedDimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
-        $unlocalizedDimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
-
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn(null);
-
-        $workflowMapper->map($data, $dimensionContentCollection->reveal());
-    }
-
-    public function testMapUnlocalizedLive(): void
-    {
-        $workflowMapper = $this->createWorkflowDataMapperInstance();
-
-        $data = [
-            'published' => (new \DateTime())->format('c'),
-        ];
-
-        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $unlocalizedDimensionContent->willImplement(WorkflowInterface::class);
-        $unlocalizedDimensionContent->getStage()->willReturn(DimensionContentInterface::STAGE_LIVE);
-        $unlocalizedDimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
-        $unlocalizedDimensionContent->setWorkflowPublished(Argument::type(\DateTimeInterface::class))->shouldBeCalled();
-
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn(null);
-
-        $workflowMapper->map($data, $dimensionContentCollection->reveal());
-    }
-
-    public function testMapUnlocalizedLivePublishedNotSet(): void
-    {
-        $workflowMapper = $this->createWorkflowDataMapperInstance();
-
         $data = [];
 
-        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $unlocalizedDimensionContent->willImplement(WorkflowInterface::class);
-        $unlocalizedDimensionContent->getStage()->willReturn(DimensionContentInterface::STAGE_LIVE);
-        $unlocalizedDimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
-        $unlocalizedDimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
+        $example = new Example();
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
 
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn(null);
+        $workflowMapper = $this->createWorkflowDataMapperInstance();
+        $workflowMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
 
-        $this->expectException(\RuntimeException::class);
-
-        $workflowMapper->map($data, $dimensionContentCollection->reveal());
+        $this->assertSame('unpublished', $localizedDimensionContent->getWorkflowPlace());
+        $this->assertNull($localizedDimensionContent->getWorkflowPublished());
     }
 
-    public function testMapLocalizedDraft(): void
+    public function testMapStageData(): void
     {
-        $workflowMapper = $this->createWorkflowDataMapperInstance();
+        $publishedDate = (new \DateTime())->format('c');
+        $data = [
+            'published' => $publishedDate,
+        ];
 
+        $example = new Example();
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+
+        $workflowMapper = $this->createWorkflowDataMapperInstance();
+        $workflowMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertSame('unpublished', $localizedDimensionContent->getWorkflowPlace());
+        $workflowPublished = $localizedDimensionContent->getWorkflowPublished();
+        $this->assertNull($workflowPublished);
+    }
+
+    public function testMapLiveData(): void
+    {
+        $publishedDate = (new \DateTime())->format('c');
+        $data = [
+            'published' => $publishedDate,
+        ];
+
+        $example = new Example();
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $unlocalizedDimensionContent->setStage(DimensionContentInterface::STAGE_LIVE);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setStage(DimensionContentInterface::STAGE_LIVE);
+
+        $workflowMapper = $this->createWorkflowDataMapperInstance();
+        $workflowMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertNull($localizedDimensionContent->getWorkflowPlace());
+        $workflowPublished = $localizedDimensionContent->getWorkflowPublished();
+        $this->assertNotNull($workflowPublished);
+        $this->assertSame($publishedDate, $workflowPublished->format('c'));
+    }
+
+    public function testMapWorkflowPlaceAlreadySet(): void
+    {
+        $data = [];
+
+        $example = new Example();
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+
+        $localizedDimensionContent->setWorkflowPlace('something-else');
+
+        $workflowMapper = $this->createWorkflowDataMapperInstance();
+        $workflowMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertSame('something-else', $localizedDimensionContent->getWorkflowPlace());
+    }
+
+    public function testMapDataPublishedAlreadySet(): void
+    {
         $data = [
             'published' => (new \DateTime())->format('c'),
         ];
 
-        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $unlocalizedDimensionContent->willImplement(WorkflowInterface::class);
+        $example = new Example();
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
 
-        $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent->willImplement(WorkflowInterface::class);
-        $localizedDimensionContent->getStage()->willReturn(DimensionContentInterface::STAGE_DRAFT);
-        $localizedDimensionContent->getWorkflowPlace()->willReturn(null);
+        $localizedDimensionContent->setWorkflowPlace('something-else');
+        $localizedDimensionContent->setWorkflowPublished(new \DateTimeImmutable('2021-01-01 00:00:00'));
 
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn($localizedDimensionContent);
-
-        $unlocalizedDimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
-        $unlocalizedDimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
-
-        $localizedDimensionContent->setWorkflowPlace(WorkflowInterface::WORKFLOW_PLACE_UNPUBLISHED)->shouldBeCalled();
-        $localizedDimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
-
-        $workflowMapper->map($data, $dimensionContentCollection->reveal());
-    }
-
-    public function testMapLocalizedDraftPlaceAlreadySet(): void
-    {
         $workflowMapper = $this->createWorkflowDataMapperInstance();
+        $workflowMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
 
-        $data = [
-            'published' => (new \DateTime())->format('c'),
-        ];
-
-        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $unlocalizedDimensionContent->willImplement(WorkflowInterface::class);
-
-        $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent->willImplement(WorkflowInterface::class);
-        $localizedDimensionContent->getStage()->willReturn(DimensionContentInterface::STAGE_DRAFT);
-        $localizedDimensionContent->getWorkflowPlace()->willReturn(WorkflowInterface::WORKFLOW_PLACE_UNPUBLISHED);
-
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn($localizedDimensionContent);
-
-        $unlocalizedDimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
-        $unlocalizedDimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
-
-        $localizedDimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
-        $localizedDimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
-
-        $workflowMapper->map($data, $dimensionContentCollection->reveal());
-    }
-
-    public function testMapLocalizedLive(): void
-    {
-        $workflowMapper = $this->createWorkflowDataMapperInstance();
-
-        $data = [
-            'published' => (new \DateTime())->format('c'),
-        ];
-
-        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $unlocalizedDimensionContent->willImplement(WorkflowInterface::class);
-
-        $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent->willImplement(WorkflowInterface::class);
-        $localizedDimensionContent->getStage()->willReturn(DimensionContentInterface::STAGE_LIVE);
-
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn($localizedDimensionContent);
-
-        $unlocalizedDimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
-        $unlocalizedDimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
-
-        $localizedDimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
-        $localizedDimensionContent->setWorkflowPublished(Argument::type(\DateTimeInterface::class))->shouldBeCalled();
-
-        $workflowMapper->map($data, $dimensionContentCollection->reveal());
+        $this->assertSame('something-else', $localizedDimensionContent->getWorkflowPlace());
+        $workflowPublished = $localizedDimensionContent->getWorkflowPublished();
+        $this->assertNotNull($workflowPublished);
+        $this->assertSame('2021-01-01 00:00:00', $workflowPublished->format('Y-m-d H:i:s'));
     }
 
     public function testMapLocalizedLivePublishedNotSet(): void
     {
-        $workflowMapper = $this->createWorkflowDataMapperInstance();
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Expected "published" to be set in the data array.');
 
         $data = [];
 
-        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $unlocalizedDimensionContent->willImplement(WorkflowInterface::class);
+        $example = new Example();
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $unlocalizedDimensionContent->setStage(DimensionContentInterface::STAGE_LIVE);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setStage(DimensionContentInterface::STAGE_LIVE);
 
-        $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
-        $localizedDimensionContent->willImplement(WorkflowInterface::class);
-        $localizedDimensionContent->getStage()->willReturn(DimensionContentInterface::STAGE_LIVE);
-
-        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
-        $dimensionContentCollection->getDimensionAttributes()->willReturn(['stage' => 'draft', 'locale' => 'de']);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => null])
-            ->willReturn($unlocalizedDimensionContent);
-        $dimensionContentCollection->getDimensionContent(['stage' => 'draft', 'locale' => 'de'])
-            ->willReturn($localizedDimensionContent);
-
-        $unlocalizedDimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
-        $unlocalizedDimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
-
-        $localizedDimensionContent->setWorkflowPlace(Argument::cetera())->shouldNotBeCalled();
-        $localizedDimensionContent->setWorkflowPublished(Argument::cetera())->shouldNotBeCalled();
-
-        $this->expectException(\RuntimeException::class);
-
-        $workflowMapper->map($data, $dimensionContentCollection->reveal());
+        $workflowMapper = $this->createWorkflowDataMapperInstance();
+        $workflowMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
     }
 }

--- a/Tests/Unit/Content/Application/DimensionContentCollectionFactory/DimensionContentCollectionFactoryTest.php
+++ b/Tests/Unit/Content/Application/DimensionContentCollectionFactory/DimensionContentCollectionFactoryTest.php
@@ -74,12 +74,13 @@ class DimensionContentCollectionFactoryTest extends TestCase
 
         $contentDataMapper = $this->prophesize(ContentDataMapperInterface::class);
         $contentDataMapper->map(
-            $data,
             Argument::that(
                 function(DimensionContentCollectionInterface $collection) use ($dimensionContent1, $dimensionContent2) {
                     return [$dimensionContent1->reveal(), $dimensionContent2->reveal()] === \iterator_to_array($collection);
                 }
-            )
+            ),
+            $attributes,
+            $data
         )->shouldBeCalled();
 
         $dimensionContentCollectionFactoryInstance = $this->createDimensionContentCollectionFactoryInstance(
@@ -140,12 +141,13 @@ class DimensionContentCollectionFactoryTest extends TestCase
 
         $contentDataMapper = $this->prophesize(ContentDataMapperInterface::class);
         $contentDataMapper->map(
-            $data,
             Argument::that(
                 function(DimensionContentCollectionInterface $collection) use ($dimensionContent1, $dimensionContent2) {
                     return [$dimensionContent1->reveal(), $dimensionContent2->reveal()] === \iterator_to_array($collection);
                 }
-            )
+            ),
+            $attributes,
+            $data
         )->shouldBeCalled();
 
         $dimensionContentCollectionFactoryInstance = $this->createDimensionContentCollectionFactoryInstance(
@@ -198,12 +200,13 @@ class DimensionContentCollectionFactoryTest extends TestCase
 
         $contentDataMapper = $this->prophesize(ContentDataMapperInterface::class);
         $contentDataMapper->map(
-            $data,
             Argument::that(
                 function(DimensionContentCollectionInterface $collection) use ($dimensionContent1, $dimensionContent2) {
                     return [$dimensionContent1->reveal(), $dimensionContent2->reveal()] === \iterator_to_array($collection);
                 }
-            )
+            ),
+            $attributes,
+            $data
         )->shouldBeCalled();
         $dimensionContentCollectionFactoryInstance = $this->createDimensionContentCollectionFactoryInstance(
             $attributes,

--- a/Tests/Unit/Content/Infrastructure/Sulu/Preview/ContentObjectProviderTest.php
+++ b/Tests/Unit/Content/Infrastructure/Sulu/Preview/ContentObjectProviderTest.php
@@ -29,6 +29,7 @@ use Sulu\Bundle\ContentBundle\Content\Domain\Model\TemplateInterface;
 use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Preview\ContentObjectProvider;
 use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Preview\PreviewDimensionContentCollection;
 use Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\Example;
+use Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
 
 class ContentObjectProviderTest extends TestCase
 {
@@ -193,17 +194,19 @@ class ContentObjectProviderTest extends TestCase
             'excerptIcon' => ['id' => 4],
         ]
     ): void {
-        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $example = new Example();
+        $exampleDimensionContent = new ExampleDimensionContent($example);
 
-        $this->contentObjectProvider->setValues($dimensionContent->reveal(), $locale, $data);
+        $this->contentObjectProvider->setValues($exampleDimensionContent, $locale, $data);
 
         $this->contentDataMapper->map(
-            $data,
             Argument::that(
-                function(PreviewDimensionContentCollection $dimensionContentCollection) use ($dimensionContent) {
-                    return $dimensionContent->reveal() === $dimensionContentCollection->getDimensionContent([]);
+                function(PreviewDimensionContentCollection $dimensionContentCollection) use ($exampleDimensionContent) {
+                    return $exampleDimensionContent === $dimensionContentCollection->getDimensionContent([]);
                 }
-            )
+            ),
+            ['locale' => 'de', 'stage' => 'draft'],
+            $data
         )->shouldBeCalledTimes(1);
     }
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,53 @@
 # Upgrade
 
+## 0.7.0
+
+### ContentMapperInterface changed
+
+The `ContentMapperInterface` has changed.
+
+**Before**
+
+```php
+    public function map(
+        array $data,
+        DimensionContentCollectionInterface $dimensionContentCollection
+    ): void;
+```
+
+**After**
+
+```php
+    public function map(
+        DimensionContentCollectionInterface $dimensionContentCollection,
+        array $dimensionAttributes,
+        array $data
+    ): void;
+```
+
+### DataMapperInterface changed
+
+The `DataMapperInterface` has changed to make the mapper easier to set localized and unlocalized data.
+
+**Before**
+
+```php
+    public function map(
+        array $data,
+        DimensionContentCollectionInterface $dimensionContentCollection
+    ): void;
+```
+
+**After**
+
+```php
+    public function map(
+        DimensionContentInterface $unlocalizedDimensionContent,
+        DimensionContentInterface $localizedDimensionContent,
+        array $data
+    ): void;
+```
+
 ## 0.6.0
 
 ### Adjusted ContentDataMapper to accept DimensionContentCollection instead of separate objects

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,7 +4,7 @@
 
 ### ContentMapperInterface changed
 
-The `ContentMapperInterface` has changed.
+The `ContentMapperInterface` was changed as a preparation for refactoring the `DimensionContentCollection`:
 
 **Before**
 
@@ -27,7 +27,7 @@ The `ContentMapperInterface` has changed.
 
 ### DataMapperInterface changed
 
-The `DataMapperInterface` has changed to make the mapper easier to set localized and unlocalized data.
+The `DataMapperInterface` was changed to make it easier to set localized and unlocalized data:
 
 **Before**
 


### PR DESCRIPTION
For making the mapper easier to handle and avoid check for localized and unlocalized dimension I for changing the interface to the following way.


TODO:

 - [x] UPGRADE.md DataMapperInterface