### PR TITLE
Fix no id in dimension content repository

### DIFF
--- a/Content/Infrastructure/Doctrine/DimensionContentRepository.php
+++ b/Content/Infrastructure/Doctrine/DimensionContentRepository.php
@@ -57,8 +57,7 @@ class DimensionContentRepository implements DimensionContentRepositoryInterface
 
         $queryBuilder = $this->entityManager->createQueryBuilder()
             ->from($dimensionContentClass, 'dimensionContent')
-            ->innerJoin('dimensionContent.' . $mappingProperty, 'content')
-            ->where('content.id = :id')
+            ->where('dimensionContent.' . $mappingProperty . ' = :id')
             ->setParameter('id', $contentRichEntity->getId());
 
         $this->dimensionContentQueryEnhancer->addSelects(


### PR DESCRIPTION
If the content rich entity uses `uuid` instead of `id` the query should still work.