### PR TITLE
Fix object provider and route defaults provider without id

### DIFF
--- a/Content/Infrastructure/Sulu/Preview/ContentObjectProvider.php
+++ b/Content/Infrastructure/Sulu/Preview/ContentObjectProvider.php
@@ -80,7 +80,7 @@ class ContentObjectProvider implements PreviewObjectProviderInterface
             $contentRichEntity = $this->entityManager->createQueryBuilder()
                 ->select('entity')
                 ->from($this->contentRichEntityClass, 'entity')
-                ->where('entity.id = :id')
+                ->where('entity = :id')
                 ->setParameter('id', $id)
                 ->getQuery()
                 ->getSingleResult();

--- a/Content/Infrastructure/Sulu/Route/ContentRouteDefaultsProvider.php
+++ b/Content/Infrastructure/Sulu/Route/ContentRouteDefaultsProvider.php
@@ -121,7 +121,7 @@ class ContentRouteDefaultsProvider implements RouteDefaultsProviderInterface
             $contentRichEntity = $this->entityManager->createQueryBuilder()
                 ->select('entity')
                 ->from($entityClass, 'entity')
-                ->where('entity.id = :id')
+                ->where('entity = :id')
                 ->setParameter('id', $id)
                 ->getQuery()
                 ->getSingleResult();

--- a/Tests/Unit/Content/Infrastructure/Sulu/Route/ContentRouteDefaultsProviderTest.php
+++ b/Tests/Unit/Content/Infrastructure/Sulu/Route/ContentRouteDefaultsProviderTest.php
@@ -94,7 +94,7 @@ class ContentRouteDefaultsProviderTest extends TestCase
         $entityManager->createQueryBuilder()->willReturn($queryBuilder->reveal());
         $queryBuilder->select('entity')->willReturn($queryBuilder->reveal());
         $queryBuilder->from(Example::class, 'entity')->willReturn($queryBuilder->reveal());
-        $queryBuilder->where('entity.id = :id')->willReturn($queryBuilder->reveal());
+        $queryBuilder->where('entity = :id')->willReturn($queryBuilder->reveal());
         $queryBuilder->setParameter('id', '123-123-123')->willReturn($queryBuilder->reveal());
         $queryBuilder->getQuery()->willReturn($query);
         $query->getSingleResult()->willReturn($contentRichEntity->reveal());
@@ -127,7 +127,7 @@ class ContentRouteDefaultsProviderTest extends TestCase
         $entityManager->createQueryBuilder()->willReturn($queryBuilder->reveal());
         $queryBuilder->select('entity')->willReturn($queryBuilder->reveal());
         $queryBuilder->from(Example::class, 'entity')->willReturn($queryBuilder->reveal());
-        $queryBuilder->where('entity.id = :id')->willReturn($queryBuilder->reveal());
+        $queryBuilder->where('entity = :id')->willReturn($queryBuilder->reveal());
         $queryBuilder->setParameter('id', '123-123-123')->willReturn($queryBuilder->reveal());
         $queryBuilder->getQuery()->willReturn($query);
         $query->getSingleResult()->willThrow(new NoResultException());
@@ -159,7 +159,7 @@ class ContentRouteDefaultsProviderTest extends TestCase
         $entityManager->createQueryBuilder()->willReturn($queryBuilder->reveal());
         $queryBuilder->select('entity')->willReturn($queryBuilder->reveal());
         $queryBuilder->from(Example::class, 'entity')->willReturn($queryBuilder->reveal());
-        $queryBuilder->where('entity.id = :id')->willReturn($queryBuilder->reveal());
+        $queryBuilder->where('entity = :id')->willReturn($queryBuilder->reveal());
         $queryBuilder->setParameter('id', '123-123-123')->willReturn($queryBuilder->reveal());
         $queryBuilder->getQuery()->willReturn($query);
         $query->getSingleResult()->willReturn($contentRichEntity->reveal());
@@ -197,7 +197,7 @@ class ContentRouteDefaultsProviderTest extends TestCase
         $entityManager->createQueryBuilder()->willReturn($queryBuilder->reveal());
         $queryBuilder->select('entity')->willReturn($queryBuilder->reveal());
         $queryBuilder->from(Example::class, 'entity')->willReturn($queryBuilder->reveal());
-        $queryBuilder->where('entity.id = :id')->willReturn($queryBuilder->reveal());
+        $queryBuilder->where('entity = :id')->willReturn($queryBuilder->reveal());
         $queryBuilder->setParameter('id', '123-123-123')->willReturn($queryBuilder->reveal());
         $queryBuilder->getQuery()->willReturn($query);
         $query->getSingleResult()->willReturn($contentRichEntity->reveal());
@@ -234,7 +234,7 @@ class ContentRouteDefaultsProviderTest extends TestCase
         $entityManager->createQueryBuilder()->willReturn($queryBuilder->reveal());
         $queryBuilder->select('entity')->willReturn($queryBuilder->reveal());
         $queryBuilder->from(Example::class, 'entity')->willReturn($queryBuilder->reveal());
-        $queryBuilder->where('entity.id = :id')->willReturn($queryBuilder->reveal());
+        $queryBuilder->where('entity = :id')->willReturn($queryBuilder->reveal());
         $queryBuilder->setParameter('id', '123-123-123')->willReturn($queryBuilder->reveal());
         $queryBuilder->getQuery()->willReturn($query);
         $query->getSingleResult()->willReturn($contentRichEntity->reveal());
@@ -277,7 +277,7 @@ class ContentRouteDefaultsProviderTest extends TestCase
         $entityManager->createQueryBuilder()->willReturn($queryBuilder->reveal());
         $queryBuilder->select('entity')->willReturn($queryBuilder->reveal());
         $queryBuilder->from(Example::class, 'entity')->willReturn($queryBuilder->reveal());
-        $queryBuilder->where('entity.id = :id')->willReturn($queryBuilder->reveal());
+        $queryBuilder->where('entity = :id')->willReturn($queryBuilder->reveal());
         $queryBuilder->setParameter('id', '123-123-123')->willReturn($queryBuilder->reveal());
         $queryBuilder->getQuery()->willReturn($query);
         $query->getSingleResult()->willReturn($contentRichEntity->reveal());
@@ -343,7 +343,7 @@ class ContentRouteDefaultsProviderTest extends TestCase
         $entityManager->createQueryBuilder()->willReturn($queryBuilder->reveal());
         $queryBuilder->select('entity')->willReturn($queryBuilder->reveal());
         $queryBuilder->from(Example::class, 'entity')->willReturn($queryBuilder->reveal());
-        $queryBuilder->where('entity.id = :id')->willReturn($queryBuilder->reveal());
+        $queryBuilder->where('entity = :id')->willReturn($queryBuilder->reveal());
         $queryBuilder->setParameter('id', '123-123-123')->willReturn($queryBuilder->reveal());
         $queryBuilder->getQuery()->willReturn($query);
         $query->getSingleResult()->willReturn($contentRichEntity->reveal());
@@ -394,7 +394,7 @@ class ContentRouteDefaultsProviderTest extends TestCase
         $entityManager->createQueryBuilder()->willReturn($queryBuilder->reveal());
         $queryBuilder->select('entity')->willReturn($queryBuilder->reveal());
         $queryBuilder->from(Example::class, 'entity')->willReturn($queryBuilder->reveal());
-        $queryBuilder->where('entity.id = :id')->willReturn($queryBuilder->reveal());
+        $queryBuilder->where('entity = :id')->willReturn($queryBuilder->reveal());
         $queryBuilder->setParameter('id', '123-123-123')->willReturn($queryBuilder->reveal());
         $queryBuilder->getQuery()->willReturn($query);
         $query->getSingleResult()->willReturn($contentRichEntity->reveal());
@@ -431,7 +431,7 @@ class ContentRouteDefaultsProviderTest extends TestCase
         $entityManager->createQueryBuilder()->willReturn($queryBuilder->reveal());
         $queryBuilder->select('entity')->willReturn($queryBuilder->reveal());
         $queryBuilder->from(Example::class, 'entity')->willReturn($queryBuilder->reveal());
-        $queryBuilder->where('entity.id = :id')->willReturn($queryBuilder->reveal());
+        $queryBuilder->where('entity = :id')->willReturn($queryBuilder->reveal());
         $queryBuilder->setParameter('id', '123-123-123')->willReturn($queryBuilder->reveal());
         $queryBuilder->getQuery()->willReturn($query);
         $query->getSingleResult()->willReturn($contentRichEntity->reveal());


### PR DESCRIPTION
If an entity has not an id instead of uuid as identifier the query in content object provider should not fail. In future the entity for `smart_content`, `preview`, `route default provider` and `workflow` should be provided over a `ContentObjectProvider` and not by a query build inside the content bundle. 