### PR TITLE
Fix set authored and author to null

### DIFF
--- a/Content/Application/ContentDataMapper/DataMapper/AuthorDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/AuthorDataMapper.php
@@ -47,11 +47,19 @@ class AuthorDataMapper implements DataMapperInterface
     private function setAuthorData(AuthorInterface $dimensionContent, array $data): void
     {
         if (\array_key_exists('author', $data)) {
-            $dimensionContent->setAuthor($this->contactFactory->create($data['author']));
+            $dimensionContent->setAuthor(
+                $data['author']
+                    ? $this->contactFactory->create($data['author'])
+                    : null
+            );
         }
 
         if (\array_key_exists('authored', $data)) {
-            $dimensionContent->setAuthored(new \DateTimeImmutable($data['authored']));
+            $dimensionContent->setAuthored(
+                $data['authored']
+                    ? new \DateTimeImmutable($data['authored'])
+                    : null
+            );
         }
     }
 }

--- a/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/AuthorDataMapperTest.php
+++ b/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/AuthorDataMapperTest.php
@@ -111,9 +111,11 @@ class AuthorDataMapperTest extends TestCase
         $example = new Example();
         $unlocalizedDimensionContent = new ExampleDimensionContent($example);
         $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setAuthor(new Contact());
+        $localizedDimensionContent->setAuthored(new \DateTimeImmutable());
 
         $this->contactFactory->create(Argument::cetera())
-            ->shouldBeNotCalled();
+            ->shouldNotBeCalled();
 
         $authorMapper = $this->createAuthorDataMapperInstance();
         $authorMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);

--- a/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/AuthorDataMapperTest.php
+++ b/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/AuthorDataMapperTest.php
@@ -100,4 +100,25 @@ class AuthorDataMapperTest extends TestCase
         $this->assertNotNull($authored);
         $this->assertSame('2020-05-08T00:00:00+00:00', $authored->format('c'));
     }
+
+    public function testMapDataNull(): void
+    {
+        $data = [
+            'author' => null,
+            'authored' => null,
+        ];
+
+        $example = new Example();
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+
+        $this->contactFactory->create(Argument::cetera())
+            ->shouldBeNotCalled();
+
+        $authorMapper = $this->createAuthorDataMapperInstance();
+        $authorMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertNull($localizedDimensionContent->getAuthor());
+        $this->assertNull($localizedDimensionContent->getAuthored());
+    }
 }


### PR DESCRIPTION
Currently errors but also the author and authored can be null and should be able to be set to null. There are projects where author is optional so this fields should be nullable and so removeable and setable by the content manager. Fixes https://github.com/sulu/sulu/pull/4026