### PR TITLE
Add Additional Webspaces Field to Settings Tab

### DIFF
--- a/Content/Application/ContentDataMapper/DataMapper/WebspaceDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/WebspaceDataMapper.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMapper;
+
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\WebspaceInterface;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+
+class WebspaceDataMapper implements DataMapperInterface
+{
+    /**
+     * @var WebspaceManagerInterface
+     */
+    private $webspaceManager;
+
+    /**
+     * @var string|null
+     */
+    private $defaultWebspaceKey;
+
+    public function __construct(WebspaceManagerInterface $webspaceManager)
+    {
+        $this->webspaceManager = $webspaceManager;
+    }
+
+    public function map(
+        DimensionContentInterface $unlocalizedDimensionContent,
+        DimensionContentInterface $localizedDimensionContent,
+        array $data
+    ): void {
+        if (!$localizedDimensionContent instanceof WebspaceInterface) {
+            return;
+        }
+
+        $this->setWebspaceData($localizedDimensionContent, $data);
+    }
+
+    /**
+     * @param mixed[] $data
+     */
+    private function setWebspaceData(WebspaceInterface $dimensionContent, array $data): void
+    {
+        // TODO allow to configure another webspace with `<tag name="sulu_content.default_main_webspace" value="example" />`
+        //      on the template itself which will be injected with ["type" => ["template-key" => "webspace-key"]] into this service.
+        if (\array_key_exists('mainWebspace', $data)) {
+            $dimensionContent->setMainWebspace($data['mainWebspace']);
+        }
+
+        if (!$dimensionContent->getMainWebspace()) {
+            // if no main webspace is yet set a default webspace will be set
+            $dimensionContent->setMainWebspace($this->getDefaultWebspaceKey());
+        }
+    }
+
+    private function getDefaultWebspaceKey(): ?string
+    {
+        if (!$this->defaultWebspaceKey) {
+            $webspaces = $this->webspaceManager->getWebspaceCollection()->getWebspaces();
+            $webspace = \reset($webspaces);
+
+            if ($webspace) {
+                $this->defaultWebspaceKey = $webspace->getKey();
+            }
+        }
+
+        return $this->defaultWebspaceKey;
+    }
+}

--- a/Content/Application/ContentDataMapper/DataMapper/WebspaceDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/WebspaceDataMapper.php
@@ -61,6 +61,10 @@ class WebspaceDataMapper implements DataMapperInterface
             // if no main webspace is yet set a default webspace will be set
             $dimensionContent->setMainWebspace($this->getDefaultWebspaceKey());
         }
+
+        if (\array_key_exists('additionalWebspaces', $data)) {
+            $dimensionContent->setAdditionalWebspaces($data['additionalWebspaces'] ?: []);
+        }
     }
 
     private function getDefaultWebspaceKey(): ?string

--- a/Content/Application/ContentMerger/Merger/WebspaceMerger.php
+++ b/Content/Application/ContentMerger/Merger/WebspaceMerger.php
@@ -30,5 +30,9 @@ class WebspaceMerger implements MergerInterface
         if ($mainWebspace = $sourceObject->getMainWebspace()) {
             $targetObject->setMainWebspace($mainWebspace);
         }
+
+        if ($additionalWebspaces = $sourceObject->getAdditionalWebspaces()) {
+            $targetObject->setAdditionalWebspaces($additionalWebspaces);
+        }
     }
 }

--- a/Content/Application/ContentMerger/Merger/WebspaceMerger.php
+++ b/Content/Application/ContentMerger/Merger/WebspaceMerger.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Content\Application\ContentMerger\Merger;
+
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\WebspaceInterface;
+
+class WebspaceMerger implements MergerInterface
+{
+    public function merge(object $targetObject, object $sourceObject): void
+    {
+        if (!$targetObject instanceof WebspaceInterface) {
+            return;
+        }
+
+        if (!$sourceObject instanceof WebspaceInterface) {
+            return;
+        }
+
+        if ($mainWebspace = $sourceObject->getMainWebspace()) {
+            $targetObject->setMainWebspace($mainWebspace);
+        }
+    }
+}

--- a/Content/Domain/Model/WebspaceInterface.php
+++ b/Content/Domain/Model/WebspaceInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Content\Domain\Model;
+
+interface WebspaceInterface
+{
+    public function getMainWebspace(): ?string;
+
+    public function setMainWebspace(?string $mainWebspace): void;
+}

--- a/Content/Domain/Model/WebspaceInterface.php
+++ b/Content/Domain/Model/WebspaceInterface.php
@@ -18,4 +18,14 @@ interface WebspaceInterface
     public function getMainWebspace(): ?string;
 
     public function setMainWebspace(?string $mainWebspace): void;
+
+    /**
+     * @return string[]
+     */
+    public function getAdditionalWebspaces(): array;
+
+    /**
+     * @param string[] $additionalWebspaces
+     */
+    public function setAdditionalWebspaces(array $additionalWebspaces): void;
 }

--- a/Content/Domain/Model/WebspaceTrait.php
+++ b/Content/Domain/Model/WebspaceTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Content\Domain\Model;
+
+trait WebspaceTrait
+{
+    /**
+     * @var string|null
+     */
+    protected $mainWebspace;
+
+    public function getMainWebspace(): ?string
+    {
+        return $this->mainWebspace;
+    }
+
+    public function setMainWebspace(?string $mainWebspace): void
+    {
+        $this->mainWebspace = $mainWebspace;
+    }
+}

--- a/Content/Domain/Model/WebspaceTrait.php
+++ b/Content/Domain/Model/WebspaceTrait.php
@@ -20,6 +20,11 @@ trait WebspaceTrait
      */
     protected $mainWebspace;
 
+    /**
+     * @var string[]|null
+     */
+    protected $additionalWebspaces;
+
     public function getMainWebspace(): ?string
     {
         return $this->mainWebspace;
@@ -28,5 +33,31 @@ trait WebspaceTrait
     public function setMainWebspace(?string $mainWebspace): void
     {
         $this->mainWebspace = $mainWebspace;
+
+        if ($mainWebspace && !\in_array($mainWebspace, $this->additionalWebspaces ?: [], true)) {
+            // additional webspace always include also the main webspace to make query simpler
+            $this->additionalWebspaces = \array_merge($this->additionalWebspaces ?: [], [$mainWebspace]);
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAdditionalWebspaces(): array
+    {
+        return $this->additionalWebspaces ?: [];
+    }
+
+    /**
+     * @param string[] $additionalWebspaces
+     */
+    public function setAdditionalWebspaces(array $additionalWebspaces): void
+    {
+        if ($this->mainWebspace && !\in_array($this->mainWebspace, $additionalWebspaces, true)) {
+            // additional webspace always include also the main webspace to make query simpler
+            $additionalWebspaces[] = $this->mainWebspace;
+        }
+
+        $this->additionalWebspaces = $additionalWebspaces;
     }
 }

--- a/Content/Infrastructure/Doctrine/MetadataLoader.php
+++ b/Content/Infrastructure/Doctrine/MetadataLoader.php
@@ -25,6 +25,7 @@ use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ExcerptInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\SeoInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\TemplateInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\WebspaceInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\WorkflowInterface;
 use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
 use Sulu\Bundle\TagBundle\Tag\TagInterface;
@@ -92,6 +93,10 @@ class MetadataLoader implements EventSubscriber
 
             $this->addManyToMany($event, $metadata, 'excerptTags', TagInterface::class, 'tag_id');
             $this->addManyToMany($event, $metadata, 'excerptCategories', CategoryInterface::class, 'category_id');
+        }
+
+        if ($reflection->implementsInterface(WebspaceInterface::class)) {
+            $this->addField($metadata, 'mainWebspace', 'string', ['nullable' => true]);
         }
 
         if ($reflection->implementsInterface(AuthorInterface::class)) {

--- a/Content/Infrastructure/Doctrine/MetadataLoader.php
+++ b/Content/Infrastructure/Doctrine/MetadataLoader.php
@@ -97,6 +97,7 @@ class MetadataLoader implements EventSubscriber
 
         if ($reflection->implementsInterface(WebspaceInterface::class)) {
             $this->addField($metadata, 'mainWebspace', 'string', ['nullable' => true]);
+            $this->addField($metadata, 'additionalWebspaces', 'json', ['nullable' => true]);
         }
 
         if ($reflection->implementsInterface(AuthorInterface::class)) {

--- a/Content/Infrastructure/Sulu/Page/Select/WebspaceSelect.php
+++ b/Content/Infrastructure/Sulu/Page/Select/WebspaceSelect.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Page\Select;
+
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+
+class WebspaceSelect
+{
+    /**
+     * @var WebspaceManagerInterface
+     */
+    private $webspaceManager;
+
+    public function __construct(WebspaceManagerInterface $webspaceManager)
+    {
+        $this->webspaceManager = $webspaceManager;
+    }
+
+    /**
+     * @return array<array{name: string, title: string}>
+     */
+    public function getValues(): array
+    {
+        $values = [];
+        foreach ($this->webspaceManager->getWebspaceCollection() as $webspace) {
+            $values[] = [
+                'name' => $webspace->getKey(),
+                'title' => $webspace->getName(),
+            ];
+        }
+
+        return $values;
+    }
+}

--- a/Resources/config/data-mapper.xml
+++ b/Resources/config/data-mapper.xml
@@ -23,6 +23,12 @@
         </service>
 
         <service id="sulu_content.workflow_data_mapper" class="Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMapper\WorkflowDataMapper">
+            <tag name="sulu_content.data_mapper" priority="24"/>
+        </service>
+
+        <service id="sulu_content.webspace_data_mapper" class="Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMapper\WebspaceDataMapper">
+            <argument type="service" id="sulu_core.webspace.webspace_manager"/>
+
             <tag name="sulu_content.data_mapper" priority="16"/>
         </service>
 

--- a/Resources/config/forms/content_settings_author.xml
+++ b/Resources/config/forms/content_settings_author.xml
@@ -5,7 +5,7 @@
 >
     <key>content_settings_author</key>
 
-   <tag name="sulu_content.content_settings_form" instanceOf="Sulu\Bundle\ContentBundle\Content\Domain\Model\AuthorInterface" priority="50"/>
+    <tag name="sulu_content.content_settings_form" instanceOf="Sulu\Bundle\ContentBundle\Content\Domain\Model\AuthorInterface" priority="-50"/>
 
     <properties>
         <section name="author">
@@ -18,6 +18,7 @@
                         <title>sulu_content.authored_date</title>
                     </meta>
                 </property>
+
                 <property name="author" type="single_contact_selection" colspan="6">
                     <meta>
                         <title>sulu_content.author</title>

--- a/Resources/config/forms/content_settings_webspace.xml
+++ b/Resources/config/forms/content_settings_webspace.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<form xmlns="http://schemas.sulu.io/template/template"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd"
+>
+    <key>content_settings_webspace</key>
+
+    <tag name="sulu_content.content_settings_form" instanceOf="Sulu\Bundle\ContentBundle\Content\Domain\Model\WebspaceInterface" priority="-30"/>
+
+    <properties>
+        <section name="webspace">
+            <meta>
+                <title>sulu_content.webspace</title>
+            </meta>
+
+            <properties>
+                <property name="mainWebspace" type="single_select" colspan="6" spaceAfter="6">
+                    <meta>
+                        <title>sulu_content.main_webspace</title>
+                    </meta>
+
+                    <params>
+                        <param
+                            name="values"
+                            type="expression"
+                            value="service('sulu_content.webspace_select').getValues()"
+                        />
+                    </params>
+                </property>
+            </properties>
+        </section>
+    </properties>
+</form>

--- a/Resources/config/forms/content_settings_webspace.xml
+++ b/Resources/config/forms/content_settings_webspace.xml
@@ -14,9 +14,23 @@
             </meta>
 
             <properties>
-                <property name="mainWebspace" type="single_select" colspan="6" spaceAfter="6">
+                <property name="mainWebspace" type="single_select" colspan="6">
                     <meta>
                         <title>sulu_content.main_webspace</title>
+                    </meta>
+
+                    <params>
+                        <param
+                            name="values"
+                            type="expression"
+                            value="service('sulu_content.webspace_select').getValues()"
+                        />
+                    </params>
+                </property>
+
+                <property name="additionalWebspaces" type="select" colspan="6">
+                    <meta>
+                        <title>sulu_content.additional_webspaces</title>
                     </meta>
 
                     <params>

--- a/Resources/config/merger.xml
+++ b/Resources/config/merger.xml
@@ -17,6 +17,10 @@
         </service>
 
         <service id="sulu_content.seo_merger" class="Sulu\Bundle\ContentBundle\Content\Application\ContentMerger\Merger\SeoMerger">
+            <tag name="sulu_content.merger" priority="24"/>
+        </service>
+
+        <service id="sulu_content.webspace_merger" class="Sulu\Bundle\ContentBundle\Content\Application\ContentMerger\Merger\WebspaceMerger">
             <tag name="sulu_content.merger" priority="16"/>
         </service>
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -26,6 +26,13 @@
         </service>
 
         <service id="Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Admin\ContentViewBuilderFactoryInterface" alias="sulu_content.content_view_builder_factory"/>
+        <service
+            id="sulu_content.webspace_select"
+            class="Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Page\Select\WebspaceSelect"
+            public="true"
+        >
+            <argument type="service" id="sulu_core.webspace.webspace_manager"/>
+        </service>
 
         <!-- ContentMerger -->
         <service id="sulu_content.content_merger" class="Sulu\Bundle\ContentBundle\Content\Application\ContentMerger\ContentMerger">

--- a/Resources/translations/admin.de.json
+++ b/Resources/translations/admin.de.json
@@ -3,6 +3,9 @@
     "sulu_content.excerpt": "Auszug & Taxonomien",
     "sulu_content.content": "Inhalt",
     "sulu_content.published": "Veröffentlicht am",
-    "sulu_content.author": "Author",
-    "sulu_page.authored_date": "Authored Date"
+    "sulu_content.author": "Autor",
+    "sulu_content.authored_date": "Verfasst am",
+    "sulu_content.webspace": "Webspace",
+    "sulu_content.main_webspace": "Hauptwebspace",
+    "sulu_content.additional_webspaces": "Weitere Webspaces"
 }

--- a/Resources/translations/admin.en.json
+++ b/Resources/translations/admin.en.json
@@ -3,6 +3,9 @@
     "sulu_content.excerpt": "Excerpt & Taxonomies",
     "sulu_content.content": "Content",
     "sulu_content.published": "Published on",
-    "sulu_content.author": "Autor",
-    "sulu_content.authored_date": "Verfasst am"
+    "sulu_content.author": "Author",
+    "sulu_content.authored_date": "Authored Date",
+    "sulu_content.webspace": "Webspace",
+    "sulu_content.main_webspace": "Main Webspace",
+    "sulu_content.additional_webspaces": "Weitere Webspaces"
 }

--- a/Tests/Application/ExampleTestBundle/Entity/ExampleDimensionContent.php
+++ b/Tests/Application/ExampleTestBundle/Entity/ExampleDimensionContent.php
@@ -26,10 +26,12 @@ use Sulu\Bundle\ContentBundle\Content\Domain\Model\SeoInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\SeoTrait;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\TemplateInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\TemplateTrait;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\WebspaceInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\WebspaceTrait;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\WorkflowInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\WorkflowTrait;
 
-class ExampleDimensionContent implements DimensionContentInterface, ExcerptInterface, SeoInterface, TemplateInterface, RoutableInterface, WorkflowInterface, AuthorInterface
+class ExampleDimensionContent implements DimensionContentInterface, ExcerptInterface, SeoInterface, TemplateInterface, RoutableInterface, WorkflowInterface, AuthorInterface, WebspaceInterface
 {
     use AuthorTrait;
     use DimensionContentTrait;
@@ -39,6 +41,7 @@ class ExampleDimensionContent implements DimensionContentInterface, ExcerptInter
     use TemplateTrait {
         setTemplateData as parentSetTemplateData;
     }
+    use WebspaceTrait;
     use WorkflowTrait;
 
     /**

--- a/Tests/Functional/Integration/ExampleControllerTest.php
+++ b/Tests/Functional/Integration/ExampleControllerTest.php
@@ -66,6 +66,7 @@ class ExampleControllerTest extends SuluTestCase
             'excerptMedia' => null,
             'author' => null,
             'authored' => '2020-05-08T00:00:00+00:00',
+            'mainWebspace' => 'sulu-io',
         ]) ?: null);
 
         $response = $this->client->getResponse();
@@ -114,7 +115,6 @@ class ExampleControllerTest extends SuluTestCase
         self::purgeDatabase();
 
         $this->client->request('POST', '/admin/api/examples?locale=en', [], [], [], \json_encode([
-            'authored' => '2020-05-08T00:00:00+00:00',
             'template' => 'example-2',
             'title' => 'Test Example',
             'url' => '/my-example',
@@ -133,6 +133,8 @@ class ExampleControllerTest extends SuluTestCase
             'excerptCategories' => [],
             'excerptIcon' => null,
             'excerptMedia' => null,
+            'mainWebspace' => 'sulu-io',
+            'authored' => '2020-05-08T00:00:00+00:00',
         ]) ?: null);
 
         $response = $this->client->getResponse();
@@ -190,6 +192,8 @@ class ExampleControllerTest extends SuluTestCase
             'excerptCategories' => [],
             'excerptIcon' => null,
             'excerptMedia' => null,
+            'authored' => '2020-06-09T00:00:00+00:00',
+            'mainWebspace' => 'sulu-io2',
         ]) ?: null);
 
         $response = $this->client->getResponse();

--- a/Tests/Functional/Integration/ExampleControllerTest.php
+++ b/Tests/Functional/Integration/ExampleControllerTest.php
@@ -67,6 +67,7 @@ class ExampleControllerTest extends SuluTestCase
             'author' => null,
             'authored' => '2020-05-08T00:00:00+00:00',
             'mainWebspace' => 'sulu-io',
+            'additionalWebspaces' => ['sulu-io', 'sulu-io2'],
         ]) ?: null);
 
         $response = $this->client->getResponse();
@@ -134,6 +135,7 @@ class ExampleControllerTest extends SuluTestCase
             'excerptIcon' => null,
             'excerptMedia' => null,
             'mainWebspace' => 'sulu-io',
+            'additionalWebspaces' => ['sulu-io', 'sulu-io2'],
             'authored' => '2020-05-08T00:00:00+00:00',
         ]) ?: null);
 
@@ -194,6 +196,7 @@ class ExampleControllerTest extends SuluTestCase
             'excerptMedia' => null,
             'authored' => '2020-06-09T00:00:00+00:00',
             'mainWebspace' => 'sulu-io2',
+            'additionalWebspaces' => ['sulu-io', 'sulu-io2'],
         ]) ?: null);
 
         $response = $this->client->getResponse();

--- a/Tests/Functional/Integration/responses/example_get.json
+++ b/Tests/Functional/Integration/responses/example_get.json
@@ -27,5 +27,6 @@
     "template": "example-2",
     "title": "Test Example",
     "url": "/my-example",
-    "workflowPlace": "unpublished"
+    "workflowPlace": "unpublished",
+    "mainWebspace": "sulu-io"
 }

--- a/Tests/Functional/Integration/responses/example_get.json
+++ b/Tests/Functional/Integration/responses/example_get.json
@@ -28,5 +28,6 @@
     "title": "Test Example",
     "url": "/my-example",
     "workflowPlace": "unpublished",
-    "mainWebspace": "sulu-io"
+    "mainWebspace": "sulu-io",
+    "additionalWebspaces": ["sulu-io", "sulu-io2"]
 }

--- a/Tests/Functional/Integration/responses/example_post.json
+++ b/Tests/Functional/Integration/responses/example_post.json
@@ -27,5 +27,6 @@
     "template": "example-2",
     "title": "Test Example",
     "url": "/my-example",
-    "workflowPlace": "unpublished"
+    "workflowPlace": "unpublished",
+    "mainWebspace": "sulu-io"
 }

--- a/Tests/Functional/Integration/responses/example_post.json
+++ b/Tests/Functional/Integration/responses/example_post.json
@@ -28,5 +28,6 @@
     "title": "Test Example",
     "url": "/my-example",
     "workflowPlace": "unpublished",
-    "mainWebspace": "sulu-io"
+    "mainWebspace": "sulu-io",
+    "additionalWebspaces": ["sulu-io", "sulu-io2"]
 }

--- a/Tests/Functional/Integration/responses/example_post_publish.json
+++ b/Tests/Functional/Integration/responses/example_post_publish.json
@@ -27,5 +27,6 @@
     "template": "example-2",
     "title": "Test Example",
     "url": "/my-example",
-    "workflowPlace": "published"
+    "workflowPlace": "published",
+    "mainWebspace": "sulu-io"
 }

--- a/Tests/Functional/Integration/responses/example_post_publish.json
+++ b/Tests/Functional/Integration/responses/example_post_publish.json
@@ -28,5 +28,6 @@
     "title": "Test Example",
     "url": "/my-example",
     "workflowPlace": "published",
-    "mainWebspace": "sulu-io"
+    "mainWebspace": "sulu-io",
+    "additionalWebspaces": ["sulu-io", "sulu-io2"]
 }

--- a/Tests/Functional/Integration/responses/example_post_trigger_unpublish.json
+++ b/Tests/Functional/Integration/responses/example_post_trigger_unpublish.json
@@ -28,5 +28,6 @@
     "title": "Test Example",
     "url": "\/my-example",
     "workflowPlace": "unpublished",
-    "mainWebspace": "sulu-io"
+    "mainWebspace": "sulu-io",
+    "additionalWebspaces": ["sulu-io", "sulu-io2"]
 }

--- a/Tests/Functional/Integration/responses/example_post_trigger_unpublish.json
+++ b/Tests/Functional/Integration/responses/example_post_trigger_unpublish.json
@@ -27,5 +27,6 @@
     "template": "example-2",
     "title": "Test Example",
     "url": "\/my-example",
-    "workflowPlace": "unpublished"
+    "workflowPlace": "unpublished",
+    "mainWebspace": "sulu-io"
 }

--- a/Tests/Functional/Integration/responses/example_put.json
+++ b/Tests/Functional/Integration/responses/example_put.json
@@ -31,5 +31,6 @@
     "title": "Test Example 2",
     "url": "/my-example-2",
     "workflowPlace": "unpublished",
-    "mainWebspace": "sulu-io2"
+    "mainWebspace": "sulu-io2",
+    "additionalWebspaces": ["sulu-io", "sulu-io2"]
 }

--- a/Tests/Functional/Integration/responses/example_put.json
+++ b/Tests/Functional/Integration/responses/example_put.json
@@ -1,6 +1,6 @@
 {
     "author": null,
-    "authored": "2020-05-08T00:00:00+00:00",
+    "authored": "2020-06-09T00:00:00+00:00",
     "article": "<p>Test Article 2</p>",
     "blocks": null,
     "description": null,
@@ -30,5 +30,6 @@
     "template": "default",
     "title": "Test Example 2",
     "url": "/my-example-2",
-    "workflowPlace": "unpublished"
+    "workflowPlace": "unpublished",
+    "mainWebspace": "sulu-io2"
 }

--- a/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/WebspaceDataMapperTest.php
+++ b/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/WebspaceDataMapperTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Tests\Unit\Content\Application\ContentDataMapper\DataMapper;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMapper\WebspaceDataMapper;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\Example;
+use Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
+use Sulu\Component\Webspace\Manager\WebspaceCollection;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Component\Webspace\Webspace;
+
+class WebspaceDataMapperTest extends TestCase
+{
+    /**
+     * @var ObjectProphecy|WebspaceManagerInterface
+     */
+    private $webspaceManager;
+
+    /**
+     * @var WebspaceCollection
+     */
+    private $webspaceCollection;
+
+    protected function setUp(): void
+    {
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $this->webspaceCollection = new WebspaceCollection();
+        $this->webspaceManager->getWebspaceCollection()
+            ->willReturn($this->webspaceCollection);
+    }
+
+    protected function createWebspaceDataMapperInstance(): WebspaceDataMapper
+    {
+        return new WebspaceDataMapper($this->webspaceManager->reveal());
+    }
+
+    public function testMapNoWebspaceInterface(): void
+    {
+        $data = [
+            'author' => 1,
+            'authored' => '2020-05-08T00:00:00+00:00',
+        ];
+
+        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
+
+        $authorMapper = $this->createWebspaceDataMapperInstance();
+        $authorMapper->map($unlocalizedDimensionContent->reveal(), $localizedDimensionContent->reveal(), $data);
+        $this->assertTrue(true); // Avoid risky test as this is an early return test
+    }
+
+    public function testMapWebspaceNoData(): void
+    {
+        $data = [];
+
+        $example = new Example();
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+
+        $authorMapper = $this->createWebspaceDataMapperInstance();
+        $authorMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertNull($localizedDimensionContent->getMainWebspace());
+    }
+
+    public function testMapDefaultWebspace(): void
+    {
+        $data = [];
+
+        $example = new Example();
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+
+        $webspace = new Webspace();
+        $webspace->setKey('default-webspace');
+        $this->webspaceCollection->setWebspaces([$webspace]);
+
+        $authorMapper = $this->createWebspaceDataMapperInstance();
+        $authorMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertSame('default-webspace', $localizedDimensionContent->getMainWebspace());
+    }
+
+    public function testMapData(): void
+    {
+        $data = [
+            'mainWebspace' => 'example',
+        ];
+
+        $example = new Example();
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+
+        $authorMapper = $this->createWebspaceDataMapperInstance();
+        $authorMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertSame('example', $localizedDimensionContent->getMainWebspace());
+    }
+
+    public function testMapDataEmpty(): void
+    {
+        $data = [
+            'mainWebspace' => null,
+        ];
+
+        $example = new Example();
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setMainWebspace('example');
+
+        $authorMapper = $this->createWebspaceDataMapperInstance();
+        $authorMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertNull($localizedDimensionContent->getMainWebspace());
+    }
+}

--- a/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/WebspaceDataMapperTest.php
+++ b/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/WebspaceDataMapperTest.php
@@ -75,6 +75,7 @@ class WebspaceDataMapperTest extends TestCase
         $authorMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
 
         $this->assertNull($localizedDimensionContent->getMainWebspace());
+        $this->assertSame([], $localizedDimensionContent->getAdditionalWebspaces());
     }
 
     public function testMapDefaultWebspace(): void
@@ -93,12 +94,14 @@ class WebspaceDataMapperTest extends TestCase
         $authorMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
 
         $this->assertSame('default-webspace', $localizedDimensionContent->getMainWebspace());
+        $this->assertSame(['default-webspace'], $localizedDimensionContent->getAdditionalWebspaces());
     }
 
     public function testMapData(): void
     {
         $data = [
             'mainWebspace' => 'example',
+            'additionalWebspaces' => ['example', 'example2'],
         ];
 
         $example = new Example();
@@ -109,22 +112,26 @@ class WebspaceDataMapperTest extends TestCase
         $authorMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
 
         $this->assertSame('example', $localizedDimensionContent->getMainWebspace());
+        $this->assertSame(['example', 'example2'], $localizedDimensionContent->getAdditionalWebspaces());
     }
 
     public function testMapDataEmpty(): void
     {
         $data = [
             'mainWebspace' => null,
+            'additionalWebspaces' => null,
         ];
 
         $example = new Example();
         $unlocalizedDimensionContent = new ExampleDimensionContent($example);
         $localizedDimensionContent = new ExampleDimensionContent($example);
         $localizedDimensionContent->setMainWebspace('example');
+        $localizedDimensionContent->setAdditionalWebspaces(['example', 'example2']);
 
         $authorMapper = $this->createWebspaceDataMapperInstance();
         $authorMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
 
         $this->assertNull($localizedDimensionContent->getMainWebspace());
+        $this->assertSame([], $localizedDimensionContent->getAdditionalWebspaces());
     }
 }

--- a/Tests/Unit/Content/Application/ContentMerger/Merger/WebspaceMergerTest.php
+++ b/Tests/Unit/Content/Application/ContentMerger/Merger/WebspaceMergerTest.php
@@ -58,14 +58,17 @@ class WebspaceMergerTest extends TestCase
         $merger = $this->getWebspaceMergerInstance();
 
         $mainWebspace = 'sulu-io';
+        $additionalWebspaces = ['sulu-io', 'sulu-io2'];
 
         $source = $this->prophesize(DimensionContentInterface::class);
         $source->willImplement(WebspaceInterface::class);
         $source->getMainWebspace()->willReturn($mainWebspace)->shouldBeCalled();
+        $source->getAdditionalWebspaces()->willReturn($additionalWebspaces)->shouldBeCalled();
 
         $target = $this->prophesize(DimensionContentInterface::class);
         $target->willImplement(WebspaceInterface::class);
         $target->setMainWebspace($mainWebspace)->shouldBeCalled();
+        $target->setAdditionalWebspaces($additionalWebspaces)->shouldBeCalled();
 
         $merger->merge($target->reveal(), $source->reveal());
     }
@@ -77,10 +80,12 @@ class WebspaceMergerTest extends TestCase
         $source = $this->prophesize(DimensionContentInterface::class);
         $source->willImplement(WebspaceInterface::class);
         $source->getMainWebspace()->willReturn(null)->shouldBeCalled();
+        $source->getAdditionalWebspaces()->willReturn([])->shouldBeCalled();
 
         $target = $this->prophesize(DimensionContentInterface::class);
         $target->willImplement(WebspaceInterface::class);
         $target->setMainWebspace(Argument::any())->shouldNotBeCalled();
+        $target->setAdditionalWebspaces(Argument::any())->shouldNotBeCalled();
 
         $merger->merge($target->reveal(), $source->reveal());
     }

--- a/Tests/Unit/Content/Application/ContentMerger/Merger/WebspaceMergerTest.php
+++ b/Tests/Unit/Content/Application/ContentMerger/Merger/WebspaceMergerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Tests\Unit\Content\Application\ContentMerger\Merger;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentMerger\Merger\MergerInterface;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentMerger\Merger\WebspaceMerger;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\WebspaceInterface;
+
+class WebspaceMergerTest extends TestCase
+{
+    protected function getWebspaceMergerInstance(): MergerInterface
+    {
+        return new WebspaceMerger();
+    }
+
+    public function testMergeSourceNotImplementWebspaceInterface(): void
+    {
+        $merger = $this->getWebspaceMergerInstance();
+
+        $source = $this->prophesize(DimensionContentInterface::class);
+
+        $target = $this->prophesize(DimensionContentInterface::class);
+        $target->willImplement(WebspaceInterface::class);
+        $target->setMainWebspace(Argument::any())->shouldNotBeCalled();
+
+        $merger->merge($target->reveal(), $source->reveal());
+    }
+
+    public function testMergeTargetNotImplementWebspaceInterface(): void
+    {
+        $merger = $this->getWebspaceMergerInstance();
+
+        $source = $this->prophesize(DimensionContentInterface::class);
+        $source->willImplement(WebspaceInterface::class);
+        $source->setMainWebspace(Argument::any())->shouldNotBeCalled();
+
+        $target = $this->prophesize(DimensionContentInterface::class);
+
+        $merger->merge($target->reveal(), $source->reveal());
+    }
+
+    public function testMergeSet(): void
+    {
+        $merger = $this->getWebspaceMergerInstance();
+
+        $mainWebspace = 'sulu-io';
+
+        $source = $this->prophesize(DimensionContentInterface::class);
+        $source->willImplement(WebspaceInterface::class);
+        $source->getMainWebspace()->willReturn($mainWebspace)->shouldBeCalled();
+
+        $target = $this->prophesize(DimensionContentInterface::class);
+        $target->willImplement(WebspaceInterface::class);
+        $target->setMainWebspace($mainWebspace)->shouldBeCalled();
+
+        $merger->merge($target->reveal(), $source->reveal());
+    }
+
+    public function testMergeNotSet(): void
+    {
+        $merger = $this->getWebspaceMergerInstance();
+
+        $source = $this->prophesize(DimensionContentInterface::class);
+        $source->willImplement(WebspaceInterface::class);
+        $source->getMainWebspace()->willReturn(null)->shouldBeCalled();
+
+        $target = $this->prophesize(DimensionContentInterface::class);
+        $target->willImplement(WebspaceInterface::class);
+        $target->setMainWebspace(Argument::any())->shouldNotBeCalled();
+
+        $merger->merge($target->reveal(), $source->reveal());
+    }
+}

--- a/Tests/Unit/Content/Domain/Model/WebspaceTraitTest.php
+++ b/Tests/Unit/Content/Domain/Model/WebspaceTraitTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Tests\Unit\Content\Domain\Model;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\WebspaceInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\WebspaceTrait;
+
+class WebspaceTraitTest extends TestCase
+{
+    protected function getWebspaceInstance(): WebspaceInterface
+    {
+        return new class() implements WebspaceInterface {
+            use WebspaceTrait;
+        };
+    }
+
+    public function testGetSetMainWebspace(): void
+    {
+        $model = $this->getWebspaceInstance();
+        $this->assertNull($model->getMainWebspace());
+        $model->setMainWebspace('example');
+        $this->assertSame('example', $model->getMainWebspace());
+    }
+}

--- a/Tests/Unit/Content/Domain/Model/WebspaceTraitTest.php
+++ b/Tests/Unit/Content/Domain/Model/WebspaceTraitTest.php
@@ -33,4 +33,31 @@ class WebspaceTraitTest extends TestCase
         $model->setMainWebspace('example');
         $this->assertSame('example', $model->getMainWebspace());
     }
+
+    public function testGetSetAdditionalWebspaces(): void
+    {
+        $model = $this->getWebspaceInstance();
+        $this->assertSame([], $model->getAdditionalWebspaces());
+        $model->setAdditionalWebspaces(['example', 'example2']);
+        $this->assertSame(['example', 'example2'], $model->getAdditionalWebspaces());
+    }
+
+    public function testMainWebspaceAlwaysAdditionalWebspaces(): void
+    {
+        $model = $this->getWebspaceInstance();
+        $model->setMainWebspace('example');
+
+        $this->assertSame('example', $model->getMainWebspace());
+        $this->assertSame(['example'], $model->getAdditionalWebspaces());
+    }
+
+    public function testAdditionalWebspacesWithoutMainWebspace(): void
+    {
+        $model = $this->getWebspaceInstance();
+        $model->setMainWebspace('example');
+        $model->setAdditionalWebspaces(['example-2']);
+
+        $this->assertSame('example', $model->getMainWebspace());
+        $this->assertSame(['example-2', 'example'], $model->getAdditionalWebspaces());
+    }
 }

--- a/Tests/Unit/Content/Infrastructure/Doctrine/MetadataLoaderTest.php
+++ b/Tests/Unit/Content/Infrastructure/Doctrine/MetadataLoaderTest.php
@@ -27,6 +27,7 @@ use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ExcerptInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\SeoInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\TemplateInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\WebspaceInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\WorkflowInterface;
 use Sulu\Bundle\ContentBundle\Content\Infrastructure\Doctrine\MetadataLoader;
 use Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
@@ -66,6 +67,7 @@ class MetadataLoaderTest extends TestCase
         $reflectionClass->implementsInterface(ExcerptInterface::class)->willReturn(\in_array(ExcerptInterface::class, $interfaces, true));
         $reflectionClass->implementsInterface(TemplateInterface::class)->willReturn(\in_array(TemplateInterface::class, $interfaces, true));
         $reflectionClass->implementsInterface(WorkflowInterface::class)->willReturn(\in_array(WorkflowInterface::class, $interfaces, true));
+        $reflectionClass->implementsInterface(WebspaceInterface::class)->willReturn(\in_array(WebspaceInterface::class, $interfaces, true));
         $reflectionClass->implementsInterface(AuthorInterface::class)->willReturn(\in_array(AuthorInterface::class, $interfaces, true));
 
         foreach ($interfaces as $interface) {
@@ -242,6 +244,17 @@ class MetadataLoaderTest extends TestCase
             [
                 'author' => true,
             ],
+        ];
+
+        yield [
+            [
+                WebspaceInterface::class,
+            ],
+            [
+                'mainWebspace' => true,
+            ],
+            [],
+            [],
         ];
     }
 }

--- a/Tests/Unit/Content/Infrastructure/Doctrine/MetadataLoaderTest.php
+++ b/Tests/Unit/Content/Infrastructure/Doctrine/MetadataLoaderTest.php
@@ -252,6 +252,7 @@ class MetadataLoaderTest extends TestCase
             ],
             [
                 'mainWebspace' => true,
+                'additionalWebspaces' => true,
             ],
             [],
             [],

--- a/Tests/Unit/Content/Infrastructure/Sulu/Page/Select/WebspaceSelectTest.php
+++ b/Tests/Unit/Content/Infrastructure/Sulu/Page/Select/WebspaceSelectTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Tests\Unit\Content\Infrastructure\Sulu\Page\Select;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Page\Select\WebspaceSelect;
+use Sulu\Component\Webspace\Manager\WebspaceCollection;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Component\Webspace\Webspace;
+
+class WebspaceSelectTest extends TestCase
+{
+    /**
+     * @var ObjectProphecy|WebspaceManagerInterface
+     */
+    private $webspaceManager;
+
+    protected function setUp(): void
+    {
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+    }
+
+    private function createWebspaceSelectInstance(): WebspaceSelect
+    {
+        return new WebspaceSelect($this->webspaceManager->reveal());
+    }
+
+    public function testGetValues(): void
+    {
+        $webspaceA = new Webspace();
+        $webspaceA->setKey('webspace-a');
+        $webspaceA->setName('Webspace A');
+        $webspaceB = new Webspace();
+        $webspaceB->setKey('webspace-b');
+        $webspaceB->setName('Webspace B');
+        $webspaceCollection = new WebspaceCollection([
+            $webspaceA,
+            $webspaceB,
+        ]);
+
+        $this->webspaceManager->getWebspaceCollection()
+            ->shouldBeCalled()
+            ->willReturn($webspaceCollection);
+
+        $webspaceSelect = $this->createWebspaceSelectInstance();
+
+        $this->assertSame(
+            [
+                [
+                    'name' => 'webspace-a',
+                    'title' => 'Webspace A',
+                ],
+                [
+                    'name' => 'webspace-b',
+                    'title' => 'Webspace B',
+                ],
+            ],
+            $webspaceSelect->getValues()
+        );
+    }
+}


### PR DESCRIPTION
Most entities like `Article` and any routable Custom Entity will have a webspace selection in its settings tab. I did go here with the name `WebspaceInterface`.

The entity like `Page` will not implement it as the webspace will there not be on the PageDimensionContent Entity and so not implement for its webspace a content interface. Other entity like snippet which will have content will not have a Webspace field or relation.

## TODO

 - [ ] Discuss how `additionalWebspaces` are saved
    - [ ] Version A: JSON Field (performant smart content query)
    - [ ] Version B: Additional Table with Webspace (primaryKey is `webspaceKey`)
    - [ ] Version C: Additional General Table (DimensionContentWebspace entity)
    - [ ] Version D: Additional Table without ORM (not sure if possible)
    
See prototype repository: https://github.com/alexander-schranz/doctrine-json-array-prototype/pull/1
    
Keep in mind for `navigationContexts` we need something similar, but as they are Page specific and will not be part of the content bundle it is not as important as `additionalWebspaces` which will be used by any entity using content bundle with routing.