### PR TITLE
Add missing joins to examples list XML

### DIFF
--- a/Tests/Application/ExampleTestBundle/Entity/ExampleDimensionContent.php
+++ b/Tests/Application/ExampleTestBundle/Entity/ExampleDimensionContent.php
@@ -82,7 +82,7 @@ class ExampleDimensionContent implements DimensionContentInterface, ExcerptInter
     public function setTemplateData(array $templateData): void
     {
         if (\array_key_exists('title', $templateData)) {
-            $this->title = $templateData['title'] ?? null;
+            $this->title = $templateData['title'];
         }
 
         $this->parentSetTemplateData($templateData);

--- a/Tests/Application/ExampleTestBundle/Resources/config/lists/examples.xml
+++ b/Tests/Application/ExampleTestBundle/Resources/config/lists/examples.xml
@@ -56,11 +56,15 @@
         <property name="locale" translation="sulu_admin.locale" visibility="never">
             <field-name>locale</field-name>
             <entity-name>dimensionContent</entity-name>
+
+            <joins ref="dimensionContent"/>
         </property>
 
         <property name="ghostLocale" translation="sulu_admin.ghost_locale" visibility="never">
             <field-name>ghostLocale</field-name>
             <entity-name>unlocalizedDimensionContent</entity-name>
+
+            <joins ref="unlocalizedDimensionContent"/>
         </property>
     </properties>
 </list>


### PR DESCRIPTION
Just a little tweak so nobody else sits there incorrectly trying to figure out what's special about case-property that makes cget fail when it's removed from the Example list.  (Plus removal of a redundancy in ExampleDimensionContent that was niggling at me.)