### PR TITLE
Add jsonb option to json field type.

### DIFF
--- a/Content/Infrastructure/Doctrine/MetadataLoader.php
+++ b/Content/Infrastructure/Doctrine/MetadataLoader.php
@@ -64,7 +64,7 @@ class MetadataLoader implements EventSubscriber
 
         if ($reflection->implementsInterface(TemplateInterface::class)) {
             $this->addField($metadata, 'templateKey', 'string', ['length' => 32]);
-            $this->addField($metadata, 'templateData', 'json', ['nullable' => false]);
+            $this->addField($metadata, 'templateData', 'json', ['nullable' => false, 'options' => ['jsonb' => true]]);
 
             $this->addIndex($metadata, 'idx_template_key', ['templateKey']);
         }

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,16 @@
 # Upgrade
 
+## 0.6.x
+
+### Add jsonb support for postgresql tables
+
+```postgresql
+ALTER TABLE test_example_dimensions
+  ALTER COLUMN templateData
+  SET DATA TYPE jsonb
+  USING templateData::jsonb;
+```
+
 ## 0.6.3
 
 ### Add dimension, templateKey, workflowPublished and workflowPlace indexes

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,14 +2,12 @@
 
 ## 0.6.x
 
-### Add jsonb support for postgresql tables
+### Use jsonb for PostgreSQL json columns
 
-```postgresql
-ALTER TABLE test_example_dimensions
-  ALTER COLUMN templateData
-  SET DATA TYPE jsonb
-  USING templateData::jsonb;
-```
+This effects only PostgreSQL databases:
+
+```sql
+ALTER TABLE <your_entity>_example_dimensions ALTER COLUMN templateData SET DATA TYPE jsonb USING templateData::jsonb;
 
 ## 0.6.3
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,7 @@ This effects only PostgreSQL databases:
 
 ```sql
 ALTER TABLE <your_entity>_example_dimensions ALTER COLUMN templateData SET DATA TYPE jsonb USING templateData::jsonb;
+```
 
 ## 0.6.3
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #219
| Related issues/PRs | #219
| License | MIT

#### What's in this PR?

Change MetadataLoader to use JSONB instead of JSON to store data in tables.

#### Why?

https://scalegrid.io/blog/using-jsonb-in-postgresql-how-to-effectively-store-index-json-data-in-postgresql/

In doctrine by adding options: ['jsonb' => true] will use when available the JSONB fieldtype instead of JSON in database like postgresql which is in most cases the better match as it allow store the data in a binary way and allow so more performant queries.

#### To Do

- [x] Add sql query to UPGRADE.md if needed