### PR TITLE
Fix example application automation and sitemap routes

### DIFF
--- a/Tests/Application/config/routing_admin.yml
+++ b/Tests/Application/config/routing_admin.yml
@@ -104,6 +104,16 @@ sulu_search:
     resource: "@SuluSearchBundle/Resources/config/routing.yml"
     prefix: /admin/search
 
+# automation
+sulu_automation_api:
+    resource: '@SuluAutomationBundle/Resources/config/routing_api.yml'
+    prefix: /admin/api
+
+sulu_automation:
+    type: rest
+    resource: '@SuluAutomationBundle/Resources/config/routing.yml'
+    prefix: /admin/automation
+
 # Custom
 example_test_api:
     type: rest

--- a/Tests/Application/config/routing_website.yml
+++ b/Tests/Application/config/routing_website.yml
@@ -4,3 +4,6 @@ sulu_media:
 sulu_search:
     type: portal
     resource: "@SuluSearchBundle/Resources/config/routing_website.yml"
+
+sulu_website:
+    resource: "@SuluWebsiteBundle/Resources/config/routing_website.yml"


### PR DESCRIPTION
Currently the `pages` crash as the routes for the automation bundle in the example test application was not available. Also the sitemap could not be tested because the route for it was not registered.