### PR TITLE
WIP: Add shadow functionality to publishing process

### DIFF
--- a/Content/Application/ContentCopier/ContentCopier.php
+++ b/Content/Application/ContentCopier/ContentCopier.php
@@ -59,29 +59,32 @@ class ContentCopier implements ContentCopierInterface
         ContentRichEntityInterface $sourceContentRichEntity,
         array $sourceDimensionAttributes,
         ContentRichEntityInterface $targetContentRichEntity,
-        array $targetDimensionAttributes
+        array $targetDimensionAttributes,
+        array $data = []
     ): DimensionContentInterface {
         $sourceDimensionContent = $this->contentResolver->resolve($sourceContentRichEntity, $sourceDimensionAttributes);
 
-        return $this->copyFromDimensionContent($sourceDimensionContent, $targetContentRichEntity, $targetDimensionAttributes);
+        return $this->copyFromDimensionContent($sourceDimensionContent, $targetContentRichEntity, $targetDimensionAttributes, $data);
     }
 
     public function copyFromDimensionContentCollection(
         DimensionContentCollectionInterface $dimensionContentCollection,
         ContentRichEntityInterface $targetContentRichEntity,
-        array $targetDimensionAttributes
+        array $targetDimensionAttributes,
+        array $data = []
     ): DimensionContentInterface {
         $sourceDimensionContent = $this->contentMerger->merge($dimensionContentCollection);
 
-        return $this->copyFromDimensionContent($sourceDimensionContent, $targetContentRichEntity, $targetDimensionAttributes);
+        return $this->copyFromDimensionContent($sourceDimensionContent, $targetContentRichEntity, $targetDimensionAttributes, $data);
     }
 
     public function copyFromDimensionContent(
         DimensionContentInterface $dimensionContent,
         ContentRichEntityInterface $targetContentRichEntity,
-        array $targetDimensionAttributes
+        array $targetDimensionAttributes,
+        array $data = []
     ): DimensionContentInterface {
-        $data = $this->contentNormalizer->normalize($dimensionContent);
+        $data = \array_merge($this->contentNormalizer->normalize($dimensionContent), $data);
 
         return $this->contentPersister->persist($targetContentRichEntity, $data, $targetDimensionAttributes);
     }

--- a/Content/Application/ContentCopier/ContentCopierInterface.php
+++ b/Content/Application/ContentCopier/ContentCopierInterface.php
@@ -26,6 +26,7 @@ interface ContentCopierInterface
      * @param mixed[] $sourceDimensionAttributes
      * @param ContentRichEntityInterface<T> $targetContentRichEntity
      * @param mixed[] $targetDimensionAttributes
+     * @param mixed[] $data This data overwrites the data of the source content
      *
      * @return T
      */
@@ -33,7 +34,8 @@ interface ContentCopierInterface
         ContentRichEntityInterface $sourceContentRichEntity,
         array $sourceDimensionAttributes,
         ContentRichEntityInterface $targetContentRichEntity,
-        array $targetDimensionAttributes
+        array $targetDimensionAttributes,
+        array $data = []
     ): DimensionContentInterface;
 
     /**
@@ -42,13 +44,15 @@ interface ContentCopierInterface
      * @param DimensionContentCollectionInterface<T> $dimensionContentCollection
      * @param ContentRichEntityInterface<T> $targetContentRichEntity
      * @param mixed[] $targetDimensionAttributes
+     * @param mixed[] $data This data overwrites the data of the source content
      *
      * @return T
      */
     public function copyFromDimensionContentCollection(
         DimensionContentCollectionInterface $dimensionContentCollection,
         ContentRichEntityInterface $targetContentRichEntity,
-        array $targetDimensionAttributes
+        array $targetDimensionAttributes,
+        array $data = []
     ): DimensionContentInterface;
 
     /**
@@ -57,12 +61,14 @@ interface ContentCopierInterface
      * @param T $dimensionContent
      * @param ContentRichEntityInterface<T> $targetContentRichEntity
      * @param mixed[] $targetDimensionAttributes
+     * @param mixed[] $data This data overwrites the data of the source content
      *
      * @return T
      */
     public function copyFromDimensionContent(
         DimensionContentInterface $dimensionContent,
         ContentRichEntityInterface $targetContentRichEntity,
-        array $targetDimensionAttributes
+        array $targetDimensionAttributes,
+        array $data = []
     ): DimensionContentInterface;
 }

--- a/Content/Domain/Model/RoutableInterface.php
+++ b/Content/Domain/Model/RoutableInterface.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\ContentBundle\Content\Domain\Model;
 
-/**
- * Marker interface for autoloading the doctrine metadata for routables.
- */
 interface RoutableInterface
 {
     public static function getResourceKey(): string;

--- a/Content/Infrastructure/Doctrine/MetadataLoader.php
+++ b/Content/Infrastructure/Doctrine/MetadataLoader.php
@@ -60,6 +60,11 @@ final class MetadataLoader implements EventSubscriber
             $this->addIndex($metadata, 'idx_stage', ['stage']);
         }
 
+        if ($reflection->implementsInterface(ShadowInterface::class)) {
+            $this->addField($metadata, 'shadowLocale', 'string', ['length' => 7, 'nullable' => true]);
+            $this->addField($metadata, 'shadowLocales', 'json', ['nullable' => true, 'options' => ['jsonb' => true]]);
+        }
+
         if ($reflection->implementsInterface(SeoInterface::class)) {
             $this->addField($metadata, 'seoTitle');
             $this->addField($metadata, 'seoDescription', 'text');
@@ -109,11 +114,6 @@ final class MetadataLoader implements EventSubscriber
 
         if ($reflection->implementsInterface(WebspaceInterface::class)) {
             $this->addField($metadata, 'mainWebspace', 'string', ['nullable' => true]);
-        }
-
-        if ($reflection->implementsInterface(ShadowInterface::class)) {
-            $this->addField($metadata, 'shadowLocale', 'string', ['length' => 7, 'nullable' => true]);
-            $this->addField($metadata, 'shadowLocales', 'json', ['nullable' => true, 'options' => ['jsonb' => true]]);
         }
 
         if ($reflection->implementsInterface(AuthorInterface::class)) {


### PR DESCRIPTION
This implements the shadowing behaviour like discussed with @chirimoya. The data of the `draft` page stays as it is and when publishing a `Shadow` page the content from the ShadowLocale will be copied to the published page.

## TODO Tests

 - [ ] DE (Published: Not Shadow, Unpublished: Shadow to EN) EN Publish should change nothing
 - [ ] DE (Published: Nothing, Unpublished: Shadow to EN) EN Publish should change nothing
 - [ ] DE (Published: Shadow, Unpublished: Not Shadow) EN Publish should update Shadow
 - [ ] DE (Published: Shadow, Unpublished: Not Shadow) DE Unpublish EN Publish should publish nothing for DE