### PR TITLE
Add shadow functionality to publishing process

### DIFF
--- a/Content/Application/ContentCopier/ContentCopier.php
+++ b/Content/Application/ContentCopier/ContentCopier.php
@@ -59,29 +59,39 @@ class ContentCopier implements ContentCopierInterface
         ContentRichEntityInterface $sourceContentRichEntity,
         array $sourceDimensionAttributes,
         ContentRichEntityInterface $targetContentRichEntity,
-        array $targetDimensionAttributes
+        array $targetDimensionAttributes,
+        array $data = [],
+        array $ignoredAttributes = []
     ): DimensionContentInterface {
         $sourceDimensionContent = $this->contentResolver->resolve($sourceContentRichEntity, $sourceDimensionAttributes);
 
-        return $this->copyFromDimensionContent($sourceDimensionContent, $targetContentRichEntity, $targetDimensionAttributes);
+        return $this->copyFromDimensionContent($sourceDimensionContent, $targetContentRichEntity, $targetDimensionAttributes, $data, $ignoredAttributes);
     }
 
     public function copyFromDimensionContentCollection(
         DimensionContentCollectionInterface $dimensionContentCollection,
         ContentRichEntityInterface $targetContentRichEntity,
-        array $targetDimensionAttributes
+        array $targetDimensionAttributes,
+        array $data = [],
+        array $ignoredAttributes = []
     ): DimensionContentInterface {
         $sourceDimensionContent = $this->contentMerger->merge($dimensionContentCollection);
 
-        return $this->copyFromDimensionContent($sourceDimensionContent, $targetContentRichEntity, $targetDimensionAttributes);
+        return $this->copyFromDimensionContent($sourceDimensionContent, $targetContentRichEntity, $targetDimensionAttributes, $data, $ignoredAttributes);
     }
 
     public function copyFromDimensionContent(
         DimensionContentInterface $dimensionContent,
         ContentRichEntityInterface $targetContentRichEntity,
-        array $targetDimensionAttributes
+        array $targetDimensionAttributes,
+        array $data = [],
+        array $ignoredAttributes = []
     ): DimensionContentInterface {
-        $data = $this->contentNormalizer->normalize($dimensionContent);
+        $data = \array_replace($this->contentNormalizer->normalize($dimensionContent), $data);
+
+        foreach ($ignoredAttributes as $ignoredAttribute) {
+            unset($data[$ignoredAttribute]);
+        }
 
         return $this->contentPersister->persist($targetContentRichEntity, $data, $targetDimensionAttributes);
     }

--- a/Content/Application/ContentCopier/ContentCopier.php
+++ b/Content/Application/ContentCopier/ContentCopier.php
@@ -60,36 +60,33 @@ class ContentCopier implements ContentCopierInterface
         array $sourceDimensionAttributes,
         ContentRichEntityInterface $targetContentRichEntity,
         array $targetDimensionAttributes,
-        array $data = [],
-        array $ignoredAttributes = []
+        array $options = []
     ): DimensionContentInterface {
         $sourceDimensionContent = $this->contentResolver->resolve($sourceContentRichEntity, $sourceDimensionAttributes);
 
-        return $this->copyFromDimensionContent($sourceDimensionContent, $targetContentRichEntity, $targetDimensionAttributes, $data, $ignoredAttributes);
+        return $this->copyFromDimensionContent($sourceDimensionContent, $targetContentRichEntity, $targetDimensionAttributes, $options);
     }
 
     public function copyFromDimensionContentCollection(
         DimensionContentCollectionInterface $dimensionContentCollection,
         ContentRichEntityInterface $targetContentRichEntity,
         array $targetDimensionAttributes,
-        array $data = [],
-        array $ignoredAttributes = []
+        array $options = []
     ): DimensionContentInterface {
         $sourceDimensionContent = $this->contentMerger->merge($dimensionContentCollection);
 
-        return $this->copyFromDimensionContent($sourceDimensionContent, $targetContentRichEntity, $targetDimensionAttributes, $data, $ignoredAttributes);
+        return $this->copyFromDimensionContent($sourceDimensionContent, $targetContentRichEntity, $targetDimensionAttributes, $options);
     }
 
     public function copyFromDimensionContent(
         DimensionContentInterface $dimensionContent,
         ContentRichEntityInterface $targetContentRichEntity,
         array $targetDimensionAttributes,
-        array $data = [],
-        array $ignoredAttributes = []
+        array $options = []
     ): DimensionContentInterface {
-        $data = \array_replace($this->contentNormalizer->normalize($dimensionContent), $data);
+        $data = \array_replace($this->contentNormalizer->normalize($dimensionContent), $options['data'] ?? []);
 
-        foreach ($ignoredAttributes as $ignoredAttribute) {
+        foreach (($options['ignoredAttributes'] ?? []) as $ignoredAttribute) {
             unset($data[$ignoredAttribute]);
         }
 

--- a/Content/Application/ContentCopier/ContentCopierInterface.php
+++ b/Content/Application/ContentCopier/ContentCopierInterface.php
@@ -26,7 +26,7 @@ interface ContentCopierInterface
      * @param mixed[] $sourceDimensionAttributes
      * @param ContentRichEntityInterface<T> $targetContentRichEntity
      * @param mixed[] $targetDimensionAttributes
-     * @param array{data?: mixed[], ignoredAttributes?: string[]} $options The "data" allows given custom data to the target and "ignoredAttributes" avoids specific attributes to be copied.
+     * @param array{data?: mixed[], ignoredAttributes?: string[]} $options the "data" allows given custom data to the target and "ignoredAttributes" avoids specific attributes to be copied
      *
      * @return T
      */
@@ -44,7 +44,7 @@ interface ContentCopierInterface
      * @param DimensionContentCollectionInterface<T> $dimensionContentCollection
      * @param ContentRichEntityInterface<T> $targetContentRichEntity
      * @param mixed[] $targetDimensionAttributes
-     * @param array{data?: mixed[], ignoredAttributes?: string[]} $options The "data" allows given custom data to the target and "ignoredAttributes" avoids specific attributes to be copied.
+     * @param array{data?: mixed[], ignoredAttributes?: string[]} $options the "data" allows given custom data to the target and "ignoredAttributes" avoids specific attributes to be copied
      *
      * @return T
      */
@@ -61,7 +61,7 @@ interface ContentCopierInterface
      * @param T $dimensionContent
      * @param ContentRichEntityInterface<T> $targetContentRichEntity
      * @param mixed[] $targetDimensionAttributes
-     * @param array{data?: mixed[], ignoredAttributes?: string[]} $options The "data" allows given custom data to the target and "ignoredAttributes" avoids specific attributes to be copied.
+     * @param array{data?: mixed[], ignoredAttributes?: string[]} $options the "data" allows given custom data to the target and "ignoredAttributes" avoids specific attributes to be copied
      *
      * @return T
      */

--- a/Content/Application/ContentCopier/ContentCopierInterface.php
+++ b/Content/Application/ContentCopier/ContentCopierInterface.php
@@ -26,8 +26,7 @@ interface ContentCopierInterface
      * @param mixed[] $sourceDimensionAttributes
      * @param ContentRichEntityInterface<T> $targetContentRichEntity
      * @param mixed[] $targetDimensionAttributes
-     * @param mixed[] $data This data is merged with the data of the source content before set on the target content
-     * @param string[] $ignoredAttributes This attributes stayed untouched
+     * @param array{data?: mixed[], ignoredAttributes?: string[]} $options The "data" allows given custom data to the target and "ignoredAttributes" avoids specific attributes to be copied.
      *
      * @return T
      */
@@ -36,8 +35,7 @@ interface ContentCopierInterface
         array $sourceDimensionAttributes,
         ContentRichEntityInterface $targetContentRichEntity,
         array $targetDimensionAttributes,
-        array $data = [],
-        array $ignoredAttributes = []
+        array $options = []
     ): DimensionContentInterface;
 
     /**
@@ -46,8 +44,7 @@ interface ContentCopierInterface
      * @param DimensionContentCollectionInterface<T> $dimensionContentCollection
      * @param ContentRichEntityInterface<T> $targetContentRichEntity
      * @param mixed[] $targetDimensionAttributes
-     * @param mixed[] $data This data is merged with the data of the source content before set on the target content
-     * @param string[] $ignoredAttributes This attributes stayed untouched
+     * @param array{data?: mixed[], ignoredAttributes?: string[]} $options The "data" allows given custom data to the target and "ignoredAttributes" avoids specific attributes to be copied.
      *
      * @return T
      */
@@ -55,8 +52,7 @@ interface ContentCopierInterface
         DimensionContentCollectionInterface $dimensionContentCollection,
         ContentRichEntityInterface $targetContentRichEntity,
         array $targetDimensionAttributes,
-        array $data = [],
-        array $ignoredAttributes = []
+        array $options = []
     ): DimensionContentInterface;
 
     /**
@@ -65,8 +61,7 @@ interface ContentCopierInterface
      * @param T $dimensionContent
      * @param ContentRichEntityInterface<T> $targetContentRichEntity
      * @param mixed[] $targetDimensionAttributes
-     * @param mixed[] $data This data is merged with the data of the source content before set on the target content
-     * @param string[] $ignoredAttributes This attributes stayed untouched
+     * @param array{data?: mixed[], ignoredAttributes?: string[]} $options The "data" allows given custom data to the target and "ignoredAttributes" avoids specific attributes to be copied.
      *
      * @return T
      */
@@ -74,7 +69,6 @@ interface ContentCopierInterface
         DimensionContentInterface $dimensionContent,
         ContentRichEntityInterface $targetContentRichEntity,
         array $targetDimensionAttributes,
-        array $data = [],
-        array $ignoredAttributes = []
+        array $options = []
     ): DimensionContentInterface;
 }

--- a/Content/Application/ContentCopier/ContentCopierInterface.php
+++ b/Content/Application/ContentCopier/ContentCopierInterface.php
@@ -26,6 +26,8 @@ interface ContentCopierInterface
      * @param mixed[] $sourceDimensionAttributes
      * @param ContentRichEntityInterface<T> $targetContentRichEntity
      * @param mixed[] $targetDimensionAttributes
+     * @param mixed[] $data This data is merged with the data of the source content before set on the target content
+     * @param string[] $ignoredAttributes This attributes stayed untouched
      *
      * @return T
      */
@@ -33,7 +35,9 @@ interface ContentCopierInterface
         ContentRichEntityInterface $sourceContentRichEntity,
         array $sourceDimensionAttributes,
         ContentRichEntityInterface $targetContentRichEntity,
-        array $targetDimensionAttributes
+        array $targetDimensionAttributes,
+        array $data = [],
+        array $ignoredAttributes = []
     ): DimensionContentInterface;
 
     /**
@@ -42,13 +46,17 @@ interface ContentCopierInterface
      * @param DimensionContentCollectionInterface<T> $dimensionContentCollection
      * @param ContentRichEntityInterface<T> $targetContentRichEntity
      * @param mixed[] $targetDimensionAttributes
+     * @param mixed[] $data This data is merged with the data of the source content before set on the target content
+     * @param string[] $ignoredAttributes This attributes stayed untouched
      *
      * @return T
      */
     public function copyFromDimensionContentCollection(
         DimensionContentCollectionInterface $dimensionContentCollection,
         ContentRichEntityInterface $targetContentRichEntity,
-        array $targetDimensionAttributes
+        array $targetDimensionAttributes,
+        array $data = [],
+        array $ignoredAttributes = []
     ): DimensionContentInterface;
 
     /**
@@ -57,12 +65,16 @@ interface ContentCopierInterface
      * @param T $dimensionContent
      * @param ContentRichEntityInterface<T> $targetContentRichEntity
      * @param mixed[] $targetDimensionAttributes
+     * @param mixed[] $data This data is merged with the data of the source content before set on the target content
+     * @param string[] $ignoredAttributes This attributes stayed untouched
      *
      * @return T
      */
     public function copyFromDimensionContent(
         DimensionContentInterface $dimensionContent,
         ContentRichEntityInterface $targetContentRichEntity,
-        array $targetDimensionAttributes
+        array $targetDimensionAttributes,
+        array $data = [],
+        array $ignoredAttributes = []
     ): DimensionContentInterface;
 }

--- a/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapper.php
@@ -108,6 +108,12 @@ class RoutableDataMapper implements DataMapperInterface
 
         /** @var string $name */
         $name = $property->getName();
+        if ('url' !== $name) {
+            throw new \RuntimeException(\sprintf(
+                'Expected a property with the name "url" but "%s" given.',
+                $name
+            )); // TODO move this validation to a compiler pass see also direct access of 'url'  in PublishTransitionSubscriber class.
+        }
 
         $currentRoutePath = $localizedDimensionContent->getTemplateData()[$name] ?? null;
         if (!\array_key_exists($name, $data) && null !== $currentRoutePath) {
@@ -194,6 +200,7 @@ class RoutableDataMapper implements DataMapperInterface
     private function getRouteProperty(StructureMetadata $metadata): ?PropertyMetadata
     {
         foreach ($metadata->getProperties() as $property) {
+            // TODO add support for page_tree_route field type: https://github.com/sulu/SuluContentBundle/issues/242
             if ('route' === $property->getType()) {
                 return $property;
             }

--- a/Content/Application/ContentDataMapper/DataMapper/ShadowDataMapper.php
+++ b/Content/Application/ContentDataMapper/DataMapper/ShadowDataMapper.php
@@ -23,7 +23,9 @@ class ShadowDataMapper implements DataMapperInterface
         DimensionContentInterface $localizedDimensionContent,
         array $data
     ): void {
-        if (!$localizedDimensionContent instanceof ShadowInterface) {
+        if (!$unlocalizedDimensionContent instanceof ShadowInterface
+            || !$localizedDimensionContent instanceof ShadowInterface
+        ) {
             return;
         }
 
@@ -33,11 +35,19 @@ class ShadowDataMapper implements DataMapperInterface
             /** @var string|null $shadowLocale */
             $shadowLocale = $data['shadowLocale'] ?? null;
 
+            $locale = $localizedDimensionContent->getLocale();
+
             $localizedDimensionContent->setShadowLocale(
-                $shadowOn
+                $shadowOn && $locale
                     ? $shadowLocale
                     : null
             );
+
+            if ($locale && $shadowLocale) {
+                $unlocalizedDimensionContent->addShadowLocale($locale, $shadowLocale);
+            } elseif ($locale) {
+                $unlocalizedDimensionContent->removeShadowLocale($locale);
+            }
         }
     }
 }

--- a/Content/Application/ContentMerger/Merger/ShadowMerger.php
+++ b/Content/Application/ContentMerger/Merger/ShadowMerger.php
@@ -35,7 +35,7 @@ final class ShadowMerger implements MergerInterface
             $targetObject->setShadowLocale($shadowLocale);
         }
 
-        foreach ($sourceObject->getShadowLocales() ?: [] as $locale => $shadowLocale) {
+        foreach (($sourceObject->getShadowLocales() ?? []) as $locale => $shadowLocale) {
             $targetObject->addShadowLocale($locale, $shadowLocale);
         }
     }

--- a/Content/Application/ContentWorkflow/Subscriber/PublishTransitionSubscriber.php
+++ b/Content/Application/ContentWorkflow/Subscriber/PublishTransitionSubscriber.php
@@ -104,11 +104,12 @@ class PublishTransitionSubscriber implements EventSubscriberInterface
                     $dimensionContentCollection,
                     $contentRichEntity,
                     $targetDimensionAttributes,
-                    [],
                     [
-                        'shadowOn',
-                        'shadowLocale',
-                        'url',
+                        'ignoredAttributes' => [
+                            'shadowOn',
+                            'shadowLocale',
+                            'url',
+                        ],
                     ]
                 );
             }
@@ -134,7 +135,7 @@ class PublishTransitionSubscriber implements EventSubscriberInterface
             $sourceDimensionAttributes,
             $contentRichEntity,
             $targetDimensionAttributes,
-            $data
+            ['data' => $data]
         );
     }
 

--- a/Content/Application/ContentWorkflow/Subscriber/PublishTransitionSubscriber.php
+++ b/Content/Application/ContentWorkflow/Subscriber/PublishTransitionSubscriber.php
@@ -18,10 +18,17 @@ use Sulu\Bundle\ContentBundle\Content\Application\ContentWorkflow\ContentWorkflo
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentRichEntityInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\ShadowInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\TemplateInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\WorkflowInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Workflow\Event\TransitionEvent;
 
+/**
+ * @final
+ *
+ * @internal this class is internal and should not be extended from or used in another context
+ */
 class PublishTransitionSubscriber implements EventSubscriberInterface
 {
     /**
@@ -66,12 +73,68 @@ class PublishTransitionSubscriber implements EventSubscriberInterface
             throw new \RuntimeException('No "contentRichEntity" given.');
         }
 
-        $dimensionAttributes['stage'] = DimensionContentInterface::STAGE_LIVE;
+        $sourceDimensionAttributes = $dimensionAttributes;
+        $targetDimensionAttributes = $dimensionAttributes;
+        $targetDimensionAttributes['stage'] = DimensionContentInterface::STAGE_LIVE;
 
-        $this->contentCopier->copyFromDimensionContentCollection(
-            $dimensionContentCollection,
+        $shadowLocale = $dimensionContent instanceof ShadowInterface
+            ? $dimensionContent->getShadowLocale()
+            : null;
+
+        /** @var string $locale */
+        $locale = $dimensionContent->getLocale();
+
+        if (!$shadowLocale) {
+            $publishedDimensionContent = $this->contentCopier->copyFromDimensionContentCollection(
+                $dimensionContentCollection,
+                $contentRichEntity,
+                $targetDimensionAttributes
+            );
+
+            if (!$publishedDimensionContent instanceof ShadowInterface) {
+                return;
+            }
+
+            $shadowLocales = $publishedDimensionContent->getShadowLocalesForLocale($locale);
+
+            foreach ($shadowLocales as $shadowLocale) {
+                $targetDimensionAttributes['locale'] = $shadowLocale;
+
+                $this->contentCopier->copyFromDimensionContentCollection(
+                    $dimensionContentCollection,
+                    $contentRichEntity,
+                    $targetDimensionAttributes,
+                    [],
+                    [
+                        'shadowOn',
+                        'shadowLocale',
+                        'url',
+                    ]
+                );
+            }
+
+            return;
+        }
+
+        $sourceDimensionAttributes['locale'] = $shadowLocale;
+        $sourceDimensionAttributes['stage'] = DimensionContentInterface::STAGE_LIVE;
+
+        $data = [
+            // @see \Sulu\Bundle\ContentBundle\Content\Application\ContentDataMapper\DataMapper\ShadowDataMapper::map
+            'shadowOn' => true,
+            'shadowLocale' => $shadowLocale,
+        ];
+
+        if ($dimensionContent instanceof TemplateInterface) {
+            $data['url'] = $dimensionContent->getTemplateData()['url'] ?? null; // TODO get correct route property
+        }
+
+        $this->contentCopier->copy(
             $contentRichEntity,
-            $dimensionAttributes
+            $sourceDimensionAttributes,
+            $contentRichEntity,
+            $targetDimensionAttributes,
+            $data
         );
     }
 

--- a/Content/Application/ContentWorkflow/Subscriber/RemoveDraftTransitionSubscriber.php
+++ b/Content/Application/ContentWorkflow/Subscriber/RemoveDraftTransitionSubscriber.php
@@ -21,6 +21,11 @@ use Sulu\Bundle\ContentBundle\Content\Domain\Model\WorkflowInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Workflow\Event\TransitionEvent;
 
+/**
+ * @final
+ *
+ * @internal this class is internal and should not be extended from or used in another context
+ */
 class RemoveDraftTransitionSubscriber implements EventSubscriberInterface
 {
     /**

--- a/Content/Application/ContentWorkflow/Subscriber/UnpublishTransitionSubscriber.php
+++ b/Content/Application/ContentWorkflow/Subscriber/UnpublishTransitionSubscriber.php
@@ -18,11 +18,17 @@ use Sulu\Bundle\ContentBundle\Content\Application\ContentWorkflow\ContentWorkflo
 use Sulu\Bundle\ContentBundle\Content\Domain\Exception\ContentNotFoundException;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentRichEntityInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\ShadowInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\WorkflowInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Repository\DimensionContentRepositoryInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Workflow\Event\TransitionEvent;
 
+/**
+ * @final
+ *
+ * @internal this class is internal and should not be extended from or used in another context
+ */
 class UnpublishTransitionSubscriber implements EventSubscriberInterface
 {
     /**
@@ -83,6 +89,10 @@ class UnpublishTransitionSubscriber implements EventSubscriberInterface
             /** @var DimensionContentInterface $unlocalizedLiveDimensionContent */
             $unlocalizedLiveDimensionContent = $dimensionContentCollection->getDimensionContent($unlocalizedLiveDimensionAttributes);  // @phpstan-ignore-line we can not define the generic of DimensionContentInterface here
             $unlocalizedLiveDimensionContent->removeAvailableLocale($locale);
+
+            if ($unlocalizedLiveDimensionContent instanceof ShadowInterface) {
+                $unlocalizedLiveDimensionContent->removeShadowLocale($locale);
+            }
         }
 
         $this->entityManager->remove($localizedLiveDimensionContent);

--- a/Content/Domain/Model/RoutableInterface.php
+++ b/Content/Domain/Model/RoutableInterface.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\ContentBundle\Content\Domain\Model;
 
-/**
- * Marker interface for autoloading the doctrine metadata for routables.
- */
 interface RoutableInterface
 {
     public static function getResourceKey(): string;

--- a/Content/Domain/Model/ShadowInterface.php
+++ b/Content/Domain/Model/ShadowInterface.php
@@ -33,7 +33,18 @@ interface ShadowInterface
     public function removeShadowLocale(string $locale): void;
 
     /**
+     * Returns the locales which shadow the given locale.
+     *
      * @return array<string, string>|null
      */
     public function getShadowLocales(): ?array;
+
+    /**
+     * @internal should only be set by content bundle services not from outside
+     *
+     * Returns the locales which shadow the given locale
+     *
+     * @return string[]
+     */
+    public function getShadowLocalesForLocale(string $shadowLocale): array;
 }

--- a/Content/Domain/Model/ShadowTrait.php
+++ b/Content/Domain/Model/ShadowTrait.php
@@ -55,14 +55,39 @@ trait ShadowTrait
      */
     public function removeShadowLocale(string $locale): void
     {
+        if (!$this->shadowLocales) {
+            return;
+        }
+
         unset($this->shadowLocales[$locale]);
+
+        if (0 === \count($this->shadowLocales)) {
+            $this->shadowLocales = null;
+        }
     }
 
     /**
-     * @return array<string, string>
+     * @internal should only be set by content bundle services not from outside
      */
     public function getShadowLocales(): ?array
     {
         return $this->shadowLocales;
+    }
+
+    /**
+     * @internal should only be set by content bundle services not from outside
+     *
+     * @return string[]
+     */
+    public function getShadowLocalesForLocale(string $shadowLocale): array
+    {
+        $locales = [];
+        foreach (($this->shadowLocales ?? []) as $locale => $localeShadowLocale) {
+            if ($localeShadowLocale === $shadowLocale) {
+                $locales[] = $locale;
+            }
+        }
+
+        return $locales;
     }
 }

--- a/Content/Infrastructure/Doctrine/DimensionContentQueryEnhancer.php
+++ b/Content/Infrastructure/Doctrine/DimensionContentQueryEnhancer.php
@@ -95,8 +95,6 @@ class DimensionContentQueryEnhancer
             'filterDimensionContent.' . $contentRichEntityAlias . ' = ' . $contentRichEntityAlias . ''
         );
 
-        // TODO filter to shadow dimension
-
         foreach ($effectiveAttributes as $key => $value) {
             if (null === $value) {
                 $queryBuilder->andWhere('filterDimensionContent.' . $key . ' IS NULL');

--- a/Content/Infrastructure/Doctrine/MetadataLoader.php
+++ b/Content/Infrastructure/Doctrine/MetadataLoader.php
@@ -60,6 +60,18 @@ final class MetadataLoader implements EventSubscriber
             $this->addIndex($metadata, 'idx_stage', ['stage']);
         }
 
+        if ($reflection->implementsInterface(ShadowInterface::class)) {
+            $this->addField($metadata, 'shadowLocale', 'string', ['length' => 7, 'nullable' => true]);
+            $this->addField($metadata, 'shadowLocales', 'json', ['nullable' => true, 'options' => ['jsonb' => true]]);
+        }
+
+        if ($reflection->implementsInterface(TemplateInterface::class)) {
+            $this->addField($metadata, 'templateKey', 'string', ['length' => 32]);
+            $this->addField($metadata, 'templateData', 'json', ['nullable' => false, 'options' => ['jsonb' => true]]);
+
+            $this->addIndex($metadata, 'idx_template_key', ['templateKey']);
+        }
+
         if ($reflection->implementsInterface(SeoInterface::class)) {
             $this->addField($metadata, 'seoTitle');
             $this->addField($metadata, 'seoDescription', 'text');
@@ -68,13 +80,6 @@ final class MetadataLoader implements EventSubscriber
             $this->addField($metadata, 'seoNoIndex', 'boolean');
             $this->addField($metadata, 'seoNoFollow', 'boolean');
             $this->addField($metadata, 'seoHideInSitemap', 'boolean');
-        }
-
-        if ($reflection->implementsInterface(TemplateInterface::class)) {
-            $this->addField($metadata, 'templateKey', 'string', ['length' => 32]);
-            $this->addField($metadata, 'templateData', 'json', ['nullable' => false, 'options' => ['jsonb' => true]]);
-
-            $this->addIndex($metadata, 'idx_template_key', ['templateKey']);
         }
 
         if ($reflection->implementsInterface(ExcerptInterface::class)) {
@@ -109,11 +114,6 @@ final class MetadataLoader implements EventSubscriber
 
         if ($reflection->implementsInterface(WebspaceInterface::class)) {
             $this->addField($metadata, 'mainWebspace', 'string', ['nullable' => true]);
-        }
-
-        if ($reflection->implementsInterface(ShadowInterface::class)) {
-            $this->addField($metadata, 'shadowLocale', 'string', ['length' => 7, 'nullable' => true]);
-            $this->addField($metadata, 'shadowLocales', 'json', ['nullable' => true, 'options' => ['jsonb' => true]]);
         }
 
         if ($reflection->implementsInterface(AuthorInterface::class)) {

--- a/Content/Infrastructure/Sulu/Admin/ContentViewBuilderFactory.php
+++ b/Content/Infrastructure/Sulu/Admin/ContentViewBuilderFactory.php
@@ -158,6 +158,10 @@ class ContentViewBuilderFactory implements ContentViewBuilderFactoryInterface
             $seoAndExcerptToolbarActions = ['save' => $toolbarActions['save']];
             $settingsToolbarActions = ['save' => $toolbarActions['save']];
         }
+        if (isset($toolbarActions['edit'])) {
+            $seoAndExcerptToolbarActions['edit'] = $toolbarActions['edit'];
+            $settingsToolbarActions['edit'] = $toolbarActions['edit'];
+        }
 
         if (!$this->hasPermission($securityContext, PermissionTypes::EDIT)) {
             unset($toolbarActions['save'], $seoAndExcerptToolbarActions['save'], $settingsToolbarActions['save']);
@@ -236,6 +240,12 @@ class ContentViewBuilderFactory implements ContentViewBuilderFactoryInterface
                 $settingsToolbarActions,
                 $dimensionContentClass
             );
+
+            foreach ($views as $view) {
+                if ($view instanceof PreviewFormViewBuilderInterface) {
+                    $view->setPreviewCondition('shadowOn != true');
+                }
+            }
         }
 
         return $views;

--- a/Tests/Functional/Integration/ExampleControllerAvailableAndShadowLocalesTest.php
+++ b/Tests/Functional/Integration/ExampleControllerAvailableAndShadowLocalesTest.php
@@ -1,0 +1,582 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Tests\Functional\Integration;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\ContentBundle\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+/**
+ * This test is responsibility to test the update of available and shadow locales based on different
+ * publishing processes.
+ *
+ * The integration test should have no impact on the coverage so we set it to coversNothing.
+ *
+ * @coversNothing
+ */
+class ExampleControllerAvailableAndShadowLocalesTest extends SuluTestCase
+{
+    /**
+     * @var KernelBrowser
+     */
+    protected $client;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->createAuthenticatedClient(
+            [],
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json']
+        );
+    }
+
+    public function testPostCreateEnDraft(): int
+    {
+        self::purgeDatabase();
+        self::initPhpcr();
+
+        $this->client->request('POST', '/admin/api/examples?locale=en', [], [], [], \json_encode([
+            'template' => 'example-2',
+            'title' => 'Test EN',
+            'url' => '/test-en',
+        ]) ?: null);
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(201, $response);
+        $content = \json_decode((string) $response->getContent(), true);
+        /** @var int $id */
+        $id = $content['id'] ?? null; // @phpstan-ignore-line
+
+        $data = $this->getDimensionContent($id);
+
+        $this->assertSame([
+            [
+                'stage' => 'draft',
+                'locale' => null,
+                'availableLocales' => ['en'],
+                'shadowLocale' => null,
+                'shadowLocales' => null,
+                'templateData' => [],
+            ],
+            [
+                'stage' => 'draft',
+                'locale' => 'en',
+                'availableLocales' => null,
+                'shadowLocale' => null,
+                'shadowLocales' => null,
+                'templateData' => [
+                    'url' => '/test-en',
+                    'title' => 'Test EN',
+                    'images' => null,
+                ],
+            ],
+        ], $data);
+
+        return $id;
+    }
+
+    /**
+     * @depends testPostCreateEnDraft
+     */
+    public function testPostCreateDeDraft(int $id): int
+    {
+        $this->client->request('PUT', '/admin/api/examples/' . $id . '?locale=de', [], [], [], \json_encode([
+            'template' => 'example-2',
+            'title' => 'Test DE',
+            'url' => '/test-de',
+            'shadowOn' => true,
+            'shadowLocale' => 'en',
+        ]) ?: null);
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        $content = \json_decode((string) $response->getContent(), true);
+        /** @var int $id */
+        $id = $content['id'] ?? null; // @phpstan-ignore-line
+
+        $data = $this->getDimensionContent($id);
+
+        $this->assertSame([
+            [
+                'stage' => 'draft',
+                'locale' => null,
+                'availableLocales' => ['en', 'de'],
+                'shadowLocale' => null,
+                'shadowLocales' => ['de' => 'en'],
+                'templateData' => [],
+            ],
+            [
+                'stage' => 'draft',
+                'locale' => 'en',
+                'availableLocales' => null,
+                'shadowLocale' => null,
+                'shadowLocales' => null,
+                'templateData' => [
+                    'url' => '/test-en',
+                    'title' => 'Test EN',
+                    'images' => null,
+                ],
+            ],
+            [
+                'stage' => 'draft',
+                'locale' => 'de',
+                'availableLocales' => null,
+                'shadowLocale' => 'en',
+                'shadowLocales' => null,
+                'templateData' => [
+                    'url' => '/test-de',
+                    'title' => 'Test DE',
+                    'images' => null,
+                ],
+            ],
+        ], $data);
+
+        return $id;
+    }
+
+    /**
+     * @depends testPostCreateDeDraft
+     */
+    public function testPostPublishEn(int $id): int
+    {
+        $this->client->request('PUT', '/admin/api/examples/' . $id . '?locale=en&action=publish', [], [], [], \json_encode([
+            'template' => 'example-2',
+            'title' => 'Test EN',
+            'url' => '/test-en',
+        ]) ?: null);
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        $content = \json_decode((string) $response->getContent(), true);
+        /** @var int $id */
+        $id = $content['id'] ?? null; // @phpstan-ignore-line
+
+        $data = $this->getDimensionContent($id);
+
+        $this->assertSame([
+            [
+                'stage' => 'draft',
+                'locale' => null,
+                'availableLocales' => ['en', 'de'],
+                'shadowLocale' => null,
+                'shadowLocales' => ['de' => 'en'],
+                'templateData' => [],
+            ],
+            [
+                'stage' => 'draft',
+                'locale' => 'en',
+                'availableLocales' => null,
+                'shadowLocale' => null,
+                'shadowLocales' => null,
+                'templateData' => [
+                    'url' => '/test-en',
+                    'title' => 'Test EN',
+                    'images' => null,
+                ],
+            ],
+            [
+                'stage' => 'draft',
+                'locale' => 'de',
+                'availableLocales' => null,
+                'shadowLocale' => 'en',
+                'shadowLocales' => null,
+                'templateData' => [
+                    'url' => '/test-de',
+                    'title' => 'Test DE',
+                    'images' => null,
+                ],
+            ],
+            [
+                'stage' => 'live',
+                'locale' => null,
+                'availableLocales' => ['en'],
+                'shadowLocale' => null,
+                'shadowLocales' => null,
+                'templateData' => [],
+            ],
+            [
+                'stage' => 'live',
+                'locale' => 'en',
+                'availableLocales' => null,
+                'shadowLocale' => null,
+                'shadowLocales' => null,
+                'templateData' => [
+                    'url' => '/test-en',
+                    'title' => 'Test EN',
+                    'images' => null,
+                ],
+            ],
+        ], $data);
+
+        return $id;
+    }
+
+    /**
+     * @depends testPostPublishEn
+     */
+    public function testPostPublishDe(int $id): int
+    {
+        $this->client->request('PUT', '/admin/api/examples/' . $id . '?locale=de&action=publish', [], [], [], \json_encode([
+            'template' => 'example-2',
+            'title' => 'Test DE',
+            'url' => '/test-de',
+            'shadowOn' => true,
+            'shadowLocale' => 'en',
+        ]) ?: null);
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        $content = \json_decode((string) $response->getContent(), true);
+        /** @var int $id */
+        $id = $content['id'] ?? null; // @phpstan-ignore-line
+
+        $data = $this->getDimensionContent($id);
+
+        $this->assertSame([
+            [
+                'stage' => 'draft',
+                'locale' => null,
+                'availableLocales' => ['en', 'de'],
+                'shadowLocale' => null,
+                'shadowLocales' => ['de' => 'en'],
+                'templateData' => [],
+            ],
+            [
+                'stage' => 'draft',
+                'locale' => 'en',
+                'availableLocales' => null,
+                'shadowLocale' => null,
+                'shadowLocales' => null,
+                'templateData' => [
+                    'url' => '/test-en',
+                    'title' => 'Test EN',
+                    'images' => null,
+                ],
+            ],
+            [
+                'stage' => 'draft',
+                'locale' => 'de',
+                'availableLocales' => null,
+                'shadowLocale' => 'en',
+                'shadowLocales' => null,
+                'templateData' => [
+                    'url' => '/test-de',
+                    'title' => 'Test DE',
+                    'images' => null,
+                ],
+            ],
+            [
+                'stage' => 'live',
+                'locale' => null,
+                'availableLocales' => ['en', 'de'],
+                'shadowLocale' => null,
+                'shadowLocales' => ['de' => 'en'],
+                'templateData' => [],
+            ],
+            [
+                'stage' => 'live',
+                'locale' => 'en',
+                'availableLocales' => null,
+                'shadowLocale' => null,
+                'shadowLocales' => null,
+                'templateData' => [
+                    'url' => '/test-en',
+                    'title' => 'Test EN',
+                    'images' => null,
+                ],
+            ],
+            [
+                'stage' => 'live',
+                'locale' => 'de',
+                'availableLocales' => null,
+                'shadowLocale' => 'en',
+                'shadowLocales' => null,
+                'templateData' => [
+                    'url' => '/test-de',
+                    'title' => 'Test EN',
+                    'images' => null,
+                ],
+            ],
+        ], $data);
+
+        return $id;
+    }
+
+    /**
+     * @depends testPostPublishDe
+     */
+    public function testPostRepublishEn(int $id): int
+    {
+        $this->client->request('PUT', '/admin/api/examples/' . $id . '?locale=en&action=publish', [], [], [], \json_encode([
+            'template' => 'example-2',
+            'title' => 'Test EN New',
+            'url' => '/test-en',
+        ]) ?: null);
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        $content = \json_decode((string) $response->getContent(), true);
+        /** @var int $id */
+        $id = $content['id'] ?? null; // @phpstan-ignore-line
+
+        $data = $this->getDimensionContent($id);
+
+        $this->assertSame([
+            [
+                'stage' => 'draft',
+                'locale' => null,
+                'availableLocales' => ['en', 'de'],
+                'shadowLocale' => null,
+                'shadowLocales' => ['de' => 'en'],
+                'templateData' => [],
+            ],
+            [
+                'stage' => 'draft',
+                'locale' => 'en',
+                'availableLocales' => null,
+                'shadowLocale' => null,
+                'shadowLocales' => null,
+                'templateData' => [
+                    'url' => '/test-en',
+                    'title' => 'Test EN New',
+                    'images' => null,
+                ],
+            ],
+            [
+                'stage' => 'draft',
+                'locale' => 'de',
+                'availableLocales' => null,
+                'shadowLocale' => 'en',
+                'shadowLocales' => null,
+                'templateData' => [
+                    'url' => '/test-de',
+                    'title' => 'Test DE',
+                    'images' => null,
+                ],
+            ],
+            [
+                'stage' => 'live',
+                'locale' => null,
+                'availableLocales' => ['en', 'de'],
+                'shadowLocale' => null,
+                'shadowLocales' => ['de' => 'en'],
+                'templateData' => [],
+            ],
+            [
+                'stage' => 'live',
+                'locale' => 'en',
+                'availableLocales' => null,
+                'shadowLocale' => null,
+                'shadowLocales' => null,
+                'templateData' => [
+                    'url' => '/test-en',
+                    'title' => 'Test EN New',
+                    'images' => null,
+                ],
+            ],
+            [
+                'stage' => 'live',
+                'locale' => 'de',
+                'availableLocales' => null,
+                'shadowLocale' => 'en',
+                'shadowLocales' => null,
+                'templateData' => [
+                    'url' => '/test-de',
+                    'title' => 'Test EN New',
+                    'images' => null,
+                ],
+            ],
+        ], $data);
+
+        return $id;
+    }
+
+    /**
+     * @depends testPostRepublishEn
+     */
+    public function testPostUnpublishDe(int $id): int
+    {
+        $this->client->request('POST', '/admin/api/examples/' . $id . '?locale=de&action=unpublish', [], [], [], \json_encode([
+            'template' => 'example-2',
+            'title' => 'Test DE',
+            'url' => '/test-de',
+            'shadowOn' => true,
+            'shadowLocale' => 'en',
+        ]) ?: null);
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        $content = \json_decode((string) $response->getContent(), true);
+        /** @var int $id */
+        $id = $content['id'] ?? null; // @phpstan-ignore-line
+
+        $data = $this->getDimensionContent($id);
+
+        $this->assertSame([
+            [
+                'stage' => 'draft',
+                'locale' => null,
+                'availableLocales' => ['en', 'de'],
+                'shadowLocale' => null,
+                'shadowLocales' => ['de' => 'en'],
+                'templateData' => [],
+            ],
+            [
+                'stage' => 'draft',
+                'locale' => 'en',
+                'availableLocales' => null,
+                'shadowLocale' => null,
+                'shadowLocales' => null,
+                'templateData' => [
+                    'url' => '/test-en',
+                    'title' => 'Test EN New',
+                    'images' => null,
+                ],
+            ],
+            [
+                'stage' => 'draft',
+                'locale' => 'de',
+                'availableLocales' => null,
+                'shadowLocale' => 'en',
+                'shadowLocales' => null,
+                'templateData' => [
+                    'url' => '/test-de',
+                    'title' => 'Test DE',
+                    'images' => null,
+                ],
+            ],
+            [
+                'stage' => 'live',
+                'locale' => null,
+                'availableLocales' => ['en'],
+                'shadowLocale' => null,
+                'shadowLocales' => null,
+                'templateData' => [],
+            ],
+            [
+                'stage' => 'live',
+                'locale' => 'en',
+                'availableLocales' => null,
+                'shadowLocale' => null,
+                'shadowLocales' => null,
+                'templateData' => [
+                    'url' => '/test-en',
+                    'title' => 'Test EN New',
+                    'images' => null,
+                ],
+            ],
+        ], $data);
+
+        return $id;
+    }
+
+    /**
+     * @depends testPostRepublishEn
+     */
+    public function testPostRepublishEnAgain(int $id): int
+    {
+        $this->client->request('PUT', '/admin/api/examples/' . $id . '?locale=en&action=publish', [], [], [], \json_encode([
+            'template' => 'example-2',
+            'title' => 'Test EN New 2',
+            'url' => '/test-en',
+        ]) ?: null);
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        $content = \json_decode((string) $response->getContent(), true);
+        /** @var int $id */
+        $id = $content['id'] ?? null; // @phpstan-ignore-line
+
+        $data = $this->getDimensionContent($id);
+
+        $this->assertSame([
+            [
+                'stage' => 'draft',
+                'locale' => null,
+                'availableLocales' => ['en', 'de'],
+                'shadowLocale' => null,
+                'shadowLocales' => ['de' => 'en'],
+                'templateData' => [],
+            ],
+            [
+                'stage' => 'draft',
+                'locale' => 'en',
+                'availableLocales' => null,
+                'shadowLocale' => null,
+                'shadowLocales' => null,
+                'templateData' => [
+                    'url' => '/test-en',
+                    'title' => 'Test EN New 2',
+                    'images' => null,
+                ],
+            ],
+            [
+                'stage' => 'draft',
+                'locale' => 'de',
+                'availableLocales' => null,
+                'shadowLocale' => 'en',
+                'shadowLocales' => null,
+                'templateData' => [
+                    'url' => '/test-de',
+                    'title' => 'Test DE',
+                    'images' => null,
+                ],
+            ],
+            [
+                'stage' => 'live',
+                'locale' => null,
+                'availableLocales' => ['en'],
+                'shadowLocale' => null,
+                'shadowLocales' => null,
+                'templateData' => [],
+            ],
+            [
+                'stage' => 'live',
+                'locale' => 'en',
+                'availableLocales' => null,
+                'shadowLocale' => null,
+                'shadowLocales' => null,
+                'templateData' => [
+                    'url' => '/test-en',
+                    'title' => 'Test EN New 2',
+                    'images' => null,
+                ],
+            ],
+        ], $data);
+
+        return $id;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    private function getDimensionContent(int $id): array
+    {
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = $this->getContainer()->get(EntityManagerInterface::class);
+        $queryBuilder = $entityManager->createQueryBuilder()
+            ->from(ExampleDimensionContent::class, 'dimensionContent')
+            ->select('dimensionContent.stage')
+            ->addSelect('dimensionContent.locale')
+            ->addSelect('dimensionContent.availableLocales')
+            ->addSelect('dimensionContent.shadowLocale')
+            ->addSelect('dimensionContent.shadowLocales')
+            ->addSelect('dimensionContent.templateData')
+            ->where('IDENTITY(dimensionContent.example) = :id')
+            ->orderBy('dimensionContent.id')
+            ->setParameter('id', $id);
+
+        return $queryBuilder->getQuery()->getArrayResult();
+    }
+}

--- a/Tests/Unit/Content/Application/ContentCopier/ContentCopierTest.php
+++ b/Tests/Unit/Content/Application/ContentCopier/ContentCopierTest.php
@@ -185,14 +185,14 @@ class ContentCopierTest extends TestCase
         $contentNormalizer->normalize($resolvedSourceContent->reveal())
             ->willReturn([
                 'resolved' => 'content',
-                'data' => 'old',
+                'overwritten' => 'old',
                 'ignored' => 'value',
             ])
             ->shouldBeCalled();
 
         $contentPersister->persist($targetContentRichEntity, [
             'resolved' => 'content',
-            'data' => 'new',
+            'overwritten' => 'new',
         ], $targetDimensionAttributes)
             ->willReturn($resolvedTargetContent->reveal())
             ->shouldBeCalled();
@@ -211,11 +211,13 @@ class ContentCopierTest extends TestCase
                 $targetContentRichEntity->reveal(),
                 $targetDimensionAttributes,
                 [
-                    'data' => 'new',
+                    'data' => [
+                        'overwritten' => 'new',
+                    ],
+                    'ignoredAttributes' => [
+                        'ignored',
+                    ],
                 ],
-                [
-                    'ignored',
-                ]
             )
         );
     }

--- a/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapperTest.php
+++ b/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapperTest.php
@@ -365,6 +365,35 @@ class RoutableDataMapperTest extends TestCase
         ], $localizedDimensionContent->getTemplateData());
     }
 
+    public function testMapRoutePropertyFalseName(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Expected a property with the name "url" but "route" given.');
+
+        $data = [
+            'route' => '/test',
+        ];
+
+        $route = new Route();
+        $route->setPath('/test-1');
+
+        $example = new Example();
+        static::setPrivateProperty($example, 'id', 1);
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $unlocalizedDimensionContent->setStage('live');
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setTemplateKey('default');
+        $localizedDimensionContent->setStage('live');
+        $localizedDimensionContent->setLocale('en');
+
+        $this->structureMetadataFactory->getStructureMetadata('example', 'default')
+            ->shouldBeCalled()
+            ->willReturn($this->createRouteStructureMetadata('route'));
+
+        $mapper = $this->createRouteDataMapperInstance();
+        $mapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+    }
+
     public function testMapRouteDraftDimension(): void
     {
         $data = [
@@ -570,11 +599,11 @@ class RoutableDataMapperTest extends TestCase
         ], $localizedDimensionContent->getTemplateData());
     }
 
-    private function createRouteStructureMetadata(): StructureMetadata
+    private function createRouteStructureMetadata(string $propertyName = 'url'): StructureMetadata
     {
         $property = $this->prophesize(PropertyMetadata::class);
         $property->getType()->willReturn('route');
-        $property->getName()->willReturn('url');
+        $property->getName()->willReturn($propertyName);
 
         $structureMetadata = $this->prophesize(StructureMetadata::class);
         $structureMetadata->getProperties()->willReturn([

--- a/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/ShadowDataMapperTest.php
+++ b/Tests/Unit/Content/Application/ContentDataMapper/DataMapper/ShadowDataMapperTest.php
@@ -38,6 +38,7 @@ class ShadowDataMapperTest extends TestCase
 
         $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
         $localizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $localizedDimensionContent->getLocale()->willReturn('en');
 
         $shadowMapper = $this->createShadowDataMapperInstance();
         $shadowMapper->map($unlocalizedDimensionContent->reveal(), $localizedDimensionContent->reveal(), $data);
@@ -52,6 +53,7 @@ class ShadowDataMapperTest extends TestCase
         $example = new Example();
         $unlocalizedDimensionContent = new ExampleDimensionContent($example);
         $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setLocale('de');
 
         $shadowMapper = $this->createShadowDataMapperInstance();
         $shadowMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
@@ -66,6 +68,7 @@ class ShadowDataMapperTest extends TestCase
         $example = new Example();
         $unlocalizedDimensionContent = new ExampleDimensionContent($example);
         $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setLocale('de');
         $localizedDimensionContent->setShadowLocale('en');
 
         $shadowMapper = $this->createShadowDataMapperInstance();
@@ -84,11 +87,34 @@ class ShadowDataMapperTest extends TestCase
         $example = new Example();
         $unlocalizedDimensionContent = new ExampleDimensionContent($example);
         $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setLocale('de');
 
         $shadowMapper = $this->createShadowDataMapperInstance();
         $shadowMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
 
         $this->assertSame('en', $localizedDimensionContent->getShadowLocale());
+        $this->assertSame(['de' => 'en'], $unlocalizedDimensionContent->getShadowLocales());
+    }
+
+    public function testMapDataRemoveShadow(): void
+    {
+        $data = [
+            'shadowOn' => false,
+            'shadowLocale' => null,
+        ];
+
+        $example = new Example();
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $unlocalizedDimensionContent->addShadowLocale('de', 'en');
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setLocale('de');
+        $localizedDimensionContent->setShadowLocale('en');
+
+        $shadowMapper = $this->createShadowDataMapperInstance();
+        $shadowMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertNull($localizedDimensionContent->getShadowLocale());
+        $this->assertNull($unlocalizedDimensionContent->getShadowLocales());
     }
 
     public function testMapDataNull(): void
@@ -100,12 +126,15 @@ class ShadowDataMapperTest extends TestCase
 
         $example = new Example();
         $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $unlocalizedDimensionContent->addShadowLocale('de', 'en');
         $localizedDimensionContent = new ExampleDimensionContent($example);
-        $localizedDimensionContent->setShadowLocale(null);
+        $localizedDimensionContent->setLocale('de');
+        $localizedDimensionContent->setShadowLocale('en');
 
         $shadowMapper = $this->createShadowDataMapperInstance();
         $shadowMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
 
         $this->assertNull($localizedDimensionContent->getShadowLocale());
+        $this->assertNull($unlocalizedDimensionContent->getShadowLocales());
     }
 }

--- a/Tests/Unit/Content/Application/ContentWorkflow/Subscriber/PublishTransitionSubscriberTest.php
+++ b/Tests/Unit/Content/Application/ContentWorkflow/Subscriber/PublishTransitionSubscriberTest.php
@@ -265,9 +265,11 @@ class PublishTransitionSubscriberTest extends TestCase
             $contentRichEntity->reveal(),
             $targetDimensionAttributes,
             [
-                'shadowOn' => true,
-                'shadowLocale' => 'de',
-                'url' => '/test-de',
+                'data' => [
+                    'shadowOn' => true,
+                    'shadowLocale' => 'de',
+                    'url' => '/test-de',
+                ],
             ]
         )
             ->willReturn($resolvedCopiedContent->reveal())
@@ -323,11 +325,12 @@ class PublishTransitionSubscriberTest extends TestCase
             $dimensionContentCollection->reveal(),
             $contentRichEntity->reveal(),
             $targetDimensionAttributes,
-            [],
             [
-                'shadowOn',
-                'shadowLocale',
-                'url',
+                'ignoredAttributes' => [
+                    'shadowOn',
+                    'shadowLocale',
+                    'url',
+                ],
             ]
         )
             ->willReturn($resolvedCopiedContent->reveal())

--- a/Tests/Unit/Content/Application/ContentWorkflow/Subscriber/PublishTransitionSubscriberTest.php
+++ b/Tests/Unit/Content/Application/ContentWorkflow/Subscriber/PublishTransitionSubscriberTest.php
@@ -15,19 +15,22 @@ namespace Sulu\Bundle\ContentBundle\Tests\Unit\Content\Application\ContentWorkfl
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentCopier\ContentCopierInterface;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentWorkflow\ContentWorkflowInterface;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentWorkflow\Subscriber\PublishTransitionSubscriber;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentRichEntityInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentCollectionInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\ShadowInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\TemplateInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\WorkflowInterface;
 use Symfony\Component\Workflow\Event\TransitionEvent;
 use Symfony\Component\Workflow\Marking;
 
 class PublishTransitionSubscriberTest extends TestCase
 {
-    use \Prophecy\PhpUnit\ProphecyTrait;
+    use ProphecyTrait;
 
     public function createContentPublisherSubscriberInstance(
         ContentCopierInterface $contentCopier
@@ -150,6 +153,7 @@ class PublishTransitionSubscriberTest extends TestCase
         $contentRichEntity = $this->prophesize(ContentRichEntityInterface::class);
         $dimensionAttributes = ['locale' => 'en', 'stage' => 'draft'];
 
+        $dimensionContent->getLocale()->willReturn('en');
         $dimensionContent->getWorkflowPublished()->willReturn(null);
         $dimensionContent->setWorkflowPublished(Argument::cetera())->shouldBeCalled();
 
@@ -189,6 +193,7 @@ class PublishTransitionSubscriberTest extends TestCase
         $contentRichEntity = $this->prophesize(ContentRichEntityInterface::class);
         $dimensionAttributes = ['locale' => 'en', 'stage' => 'draft'];
 
+        $dimensionContent->getLocale()->willReturn('en');
         $dimensionContent->getWorkflowPublished()->willReturn(new \DateTimeImmutable());
         $dimensionContent->setWorkflowPublished(Argument::any())->shouldNotBeCalled();
 
@@ -203,14 +208,127 @@ class PublishTransitionSubscriberTest extends TestCase
         ]);
 
         $contentCopier = $this->prophesize(ContentCopierInterface::class);
-        $sourceDimensionAttributes = $dimensionAttributes;
-        $sourceDimensionAttributes['stage'] = 'live';
+        $targetDimensionAttributes = $dimensionAttributes;
+        $targetDimensionAttributes['stage'] = 'live';
 
         $resolvedCopiedContent = $this->prophesize(DimensionContentInterface::class);
         $contentCopier->copyFromDimensionContentCollection(
             $dimensionContentCollection->reveal(),
             $contentRichEntity->reveal(),
-            $sourceDimensionAttributes
+            $targetDimensionAttributes
+        )
+            ->willReturn($resolvedCopiedContent->reveal())
+            ->shouldBeCalled();
+
+        $contentPublishSubscriber = $this->createContentPublisherSubscriberInstance($contentCopier->reveal());
+
+        $contentPublishSubscriber->onPublish($event);
+    }
+
+    public function testOnPublishShadow(): void
+    {
+        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $dimensionContent->willImplement(WorkflowInterface::class);
+        $dimensionContent->willImplement(ShadowInterface::class);
+        $dimensionContent->willImplement(TemplateInterface::class);
+        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
+        $contentRichEntity = $this->prophesize(ContentRichEntityInterface::class);
+        $dimensionAttributes = ['locale' => 'en', 'stage' => 'draft'];
+
+        $dimensionContent->getLocale()->willReturn('en');
+        $dimensionContent->getShadowLocale()->willReturn('de');
+        $dimensionContent->getTemplateData()->willReturn(['url' => '/test-de']);
+        $dimensionContent->getWorkflowPublished()->willReturn(null);
+        $dimensionContent->setWorkflowPublished(Argument::cetera())->shouldBeCalled();
+
+        $event = new TransitionEvent(
+            $dimensionContent->reveal(),
+            new Marking()
+        );
+        $event->setContext([
+            ContentWorkflowInterface::DIMENSION_CONTENT_COLLECTION_CONTEXT_KEY => $dimensionContentCollection->reveal(),
+            ContentWorkflowInterface::DIMENSION_ATTRIBUTES_CONTEXT_KEY => $dimensionAttributes,
+            ContentWorkflowInterface::CONTENT_RICH_ENTITY_CONTEXT_KEY => $contentRichEntity->reveal(),
+        ]);
+
+        $contentCopier = $this->prophesize(ContentCopierInterface::class);
+        $sourceDimensionAttributes = $dimensionAttributes;
+        $sourceDimensionAttributes['locale'] = 'de';
+        $sourceDimensionAttributes['stage'] = 'live';
+        $targetDimensionAttributes = $dimensionAttributes;
+        $targetDimensionAttributes['stage'] = 'live';
+
+        $resolvedCopiedContent = $this->prophesize(DimensionContentInterface::class);
+        $contentCopier->copy(
+            $contentRichEntity->reveal(),
+            $sourceDimensionAttributes,
+            $contentRichEntity->reveal(),
+            $targetDimensionAttributes,
+            [
+                'shadowOn' => true,
+                'shadowLocale' => 'de',
+                'url' => '/test-de',
+            ]
+        )
+            ->willReturn($resolvedCopiedContent->reveal())
+            ->shouldBeCalled();
+
+        $contentPublishSubscriber = $this->createContentPublisherSubscriberInstance($contentCopier->reveal());
+
+        $contentPublishSubscriber->onPublish($event);
+    }
+
+    public function testOnPublishHasShadow(): void
+    {
+        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $dimensionContent->willImplement(WorkflowInterface::class);
+        $dimensionContent->willImplement(ShadowInterface::class);
+        $dimensionContent->willImplement(TemplateInterface::class);
+        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
+        $contentRichEntity = $this->prophesize(ContentRichEntityInterface::class);
+        $dimensionAttributes = ['locale' => 'en', 'stage' => 'draft'];
+
+        $dimensionContent->getLocale()->willReturn('en');
+        $dimensionContent->getShadowLocale()->willReturn(null);
+        $dimensionContent->getWorkflowPublished()->willReturn(null);
+        $dimensionContent->setWorkflowPublished(Argument::cetera())->shouldBeCalled();
+
+        $event = new TransitionEvent(
+            $dimensionContent->reveal(),
+            new Marking()
+        );
+        $event->setContext([
+            ContentWorkflowInterface::DIMENSION_CONTENT_COLLECTION_CONTEXT_KEY => $dimensionContentCollection->reveal(),
+            ContentWorkflowInterface::DIMENSION_ATTRIBUTES_CONTEXT_KEY => $dimensionAttributes,
+            ContentWorkflowInterface::CONTENT_RICH_ENTITY_CONTEXT_KEY => $contentRichEntity->reveal(),
+        ]);
+
+        $contentCopier = $this->prophesize(ContentCopierInterface::class);
+        $targetDimensionAttributes = $dimensionAttributes;
+        $targetDimensionAttributes['stage'] = 'live';
+
+        $resolvedCopiedContent = $this->prophesize(DimensionContentInterface::class);
+        $resolvedCopiedContent->willImplement(ShadowInterface::class);
+        $resolvedCopiedContent->getShadowLocalesForLocale('en')->willReturn(['de'])->shouldBeCalled();
+        $contentCopier->copyFromDimensionContentCollection(
+            $dimensionContentCollection->reveal(),
+            $contentRichEntity->reveal(),
+            $targetDimensionAttributes
+        )
+            ->willReturn($resolvedCopiedContent->reveal())
+            ->shouldBeCalled();
+
+        $targetDimensionAttributes['locale'] = 'de';
+        $contentCopier->copyFromDimensionContentCollection(
+            $dimensionContentCollection->reveal(),
+            $contentRichEntity->reveal(),
+            $targetDimensionAttributes,
+            [],
+            [
+                'shadowOn',
+                'shadowLocale',
+                'url',
+            ]
         )
             ->willReturn($resolvedCopiedContent->reveal())
             ->shouldBeCalled();

--- a/Tests/Unit/Content/Domain/Model/ShadowTraitTest.php
+++ b/Tests/Unit/Content/Domain/Model/ShadowTraitTest.php
@@ -40,11 +40,20 @@ class ShadowTraitTest extends TestCase
     public function testAddRemoveShadowLocales(): void
     {
         $model = $this->getShadowInstance();
-        $Shadowed = new \DateTimeImmutable('2020-05-08T00:00:00+00:00');
+        $this->assertNull($model->getShadowLocales());
+        $model->removeShadowLocale('de');
         $this->assertNull($model->getShadowLocales());
         $model->addShadowLocale('de', 'en');
         $this->assertSame(['de' => 'en'], $model->getShadowLocales());
         $model->removeShadowLocale('de');
-        $this->assertSame([], $model->getShadowLocales());
+        $this->assertNull($model->getShadowLocales());
+    }
+
+    public function testGetShadowLocalesForLocale(): void
+    {
+        $model = $this->getShadowInstance();
+        $this->assertSame([], $model->getShadowLocalesForLocale('en'));
+        $model->addShadowLocale('de', 'en');
+        $this->assertSame(['de'], $model->getShadowLocalesForLocale('en'));
     }
 }

--- a/Tests/Unit/Content/Infrastructure/Sulu/Admin/ContentViewBuilderFactoryTest.php
+++ b/Tests/Unit/Content/Infrastructure/Sulu/Admin/ContentViewBuilderFactoryTest.php
@@ -215,9 +215,9 @@ class ContentViewBuilderFactoryTest extends TestCase
                 [
                     ['sulu_admin.save_with_publishing', 'sulu_admin.type', 'sulu_admin.delete', 'sulu_admin.dropdown'],
                     ['sulu_admin.save_with_publishing', 'sulu_admin.type', 'sulu_admin.delete', 'sulu_admin.dropdown'],
-                    ['sulu_admin.save_with_publishing'],
-                    ['sulu_admin.save_with_publishing'],
-                    ['sulu_admin.save_with_publishing'],
+                    ['sulu_admin.save_with_publishing', 'sulu_admin.dropdown'],
+                    ['sulu_admin.save_with_publishing', 'sulu_admin.dropdown'],
+                    ['sulu_admin.save_with_publishing', 'sulu_admin.dropdown'],
                 ],
             ],
             [
@@ -229,9 +229,9 @@ class ContentViewBuilderFactoryTest extends TestCase
                 ],
                 [
                     ['sulu_admin.save_with_publishing', 'sulu_admin.type', 'sulu_admin.delete', 'sulu_admin.dropdown'],
-                    ['sulu_admin.save_with_publishing'],
-                    ['sulu_admin.save_with_publishing'],
-                    ['sulu_admin.save_with_publishing'],
+                    ['sulu_admin.save_with_publishing', 'sulu_admin.dropdown'],
+                    ['sulu_admin.save_with_publishing', 'sulu_admin.dropdown'],
+                    ['sulu_admin.save_with_publishing', 'sulu_admin.dropdown'],
                 ],
             ],
             [
@@ -243,9 +243,9 @@ class ContentViewBuilderFactoryTest extends TestCase
                 ],
                 [
                     ['sulu_admin.save_with_publishing', 'sulu_admin.type'],
-                    ['sulu_admin.save_with_publishing'],
-                    ['sulu_admin.save_with_publishing'],
-                    ['sulu_admin.save_with_publishing'],
+                    ['sulu_admin.save_with_publishing', 'sulu_admin.dropdown'],
+                    ['sulu_admin.save_with_publishing', 'sulu_admin.dropdown'],
+                    ['sulu_admin.save_with_publishing', 'sulu_admin.dropdown'],
                 ],
             ],
             [
@@ -269,9 +269,9 @@ class ContentViewBuilderFactoryTest extends TestCase
                 [
                     ['sulu_admin.save_with_publishing', 'sulu_admin.type', 'sulu_admin.delete'],
                     ['sulu_admin.save_with_publishing', 'sulu_admin.type', 'sulu_admin.delete'],
-                    ['sulu_admin.save_with_publishing'],
-                    ['sulu_admin.save_with_publishing'],
-                    ['sulu_admin.save_with_publishing'],
+                    ['sulu_admin.save_with_publishing', 'sulu_admin.dropdown'],
+                    ['sulu_admin.save_with_publishing', 'sulu_admin.dropdown'],
+                    ['sulu_admin.save_with_publishing', 'sulu_admin.dropdown'],
                 ],
             ],
             [
@@ -284,9 +284,9 @@ class ContentViewBuilderFactoryTest extends TestCase
                 [
                     ['sulu_admin.save_with_publishing', 'sulu_admin.type', 'sulu_admin.dropdown'],
                     ['sulu_admin.save_with_publishing', 'sulu_admin.type', 'sulu_admin.dropdown'],
-                    ['sulu_admin.save_with_publishing'],
-                    ['sulu_admin.save_with_publishing'],
-                    ['sulu_admin.save_with_publishing'],
+                    ['sulu_admin.save_with_publishing', 'sulu_admin.dropdown'],
+                    ['sulu_admin.save_with_publishing', 'sulu_admin.dropdown'],
+                    ['sulu_admin.save_with_publishing', 'sulu_admin.dropdown'],
                 ],
             ],
         ];
@@ -424,9 +424,9 @@ class ContentViewBuilderFactoryTest extends TestCase
                 [
                     ['sulu_admin.save_with_publishing', 'sulu_admin.type', 'sulu_admin.delete', 'sulu_admin.dropdown'],
                     ['sulu_admin.save_with_publishing', 'sulu_admin.type', 'sulu_admin.delete', 'sulu_admin.dropdown'],
-                    ['sulu_admin.save_with_publishing'],
-                    ['sulu_admin.save_with_publishing'],
-                    ['sulu_admin.save_with_publishing'],
+                    ['sulu_admin.save_with_publishing', 'sulu_admin.dropdown'],
+                    ['sulu_admin.save_with_publishing', 'sulu_admin.dropdown'],
+                    ['sulu_admin.save_with_publishing', 'sulu_admin.dropdown'],
                 ],
             ],
         ];

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,11 @@
 
 ## 0.7.0
 
+### Route property name forced to `url`
+
+The `route` property requires now to be named `url` to make things easier accessible
+for different parts of the system.
+
 ### Add shadowLocale and shadowLocales fields
 
 To support shadow feature of sulu shadowLocale and shadowLocales fields need to be added to

--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,7 @@
         "thecodingmachine/phpstan-strict-rules": "^1.0"
     },
     "conflict": {
+        "coduo/php-matcher": "6.0.12",
         "doctrine/persistence": "1.3.2"
     },
     "config": {


### PR DESCRIPTION
This implements the shadowing behaviour like discussed with @chirimoya. The data of the `draft` page stays as it is and when publishing a `Shadow` page the content from the ShadowLocale will be copied to the published page.

## TODO Functional Tests

 - [x] DE (Published: Not Shadow, Unpublished: Shadow to EN) EN Publish should change nothing
 - [x] DE (Published: Nothing, Unpublished: Shadow to EN) EN Publish should change nothing
 - [x] DE (Published: Shadow to EN, Unpublished: Not Shadow) EN Publish should update Live Shadow
 - [x] DE (Published: Shadow to EN, Unpublished: Shadow to EN) DE Unpublish EN Publish should publish nothing for DE
 
## TODO Unit Tests

 - [x] Update PublishTransitionSubscriberTest for new cases
 - [x] Update ContentCopierTests for new Params
 - [x] Update UnublishTransitionSubscriberTest for new cases
 - [x] Update ShadowDataMapperTests for new cases