### PR TITLE
Add missing shadow logic

### DIFF
--- a/Content/Infrastructure/Sulu/Structure/ContentStructureBridge.php
+++ b/Content/Infrastructure/Sulu/Structure/ContentStructureBridge.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Structure;
 
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ShadowInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\TemplateInterface;
 use Sulu\Component\Content\Compat\Property;
@@ -440,6 +441,12 @@ class ContentStructureBridge implements StructureInterface, RoutableStructureInt
      */
     public function getContentLocales(): array
     {
+        $content = $this->getContent();
+
+        if ($content instanceof DimensionContentInterface) {
+            return $content->getAvailableLocales() ?? [];
+        }
+
         return [];
     }
 

--- a/Content/Infrastructure/Sulu/Structure/ContentStructureBridge.php
+++ b/Content/Infrastructure/Sulu/Structure/ContentStructureBridge.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Structure;
 
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\ShadowInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\TemplateInterface;
 use Sulu\Component\Content\Compat\Property;
 use Sulu\Component\Content\Compat\PropertyInterface;
@@ -402,23 +403,35 @@ class ContentStructureBridge implements StructureInterface, RoutableStructureInt
     }
 
     /**
-     * @return string[]
+     * @return array<string, string>
      */
     public function getShadowLocales(): array
     {
+        $content = $this->getContent();
+        if ($content instanceof ShadowInterface) {
+            return $content->getShadowLocales() ?? [];
+        }
+
         return [];
     }
 
-    /**
-     * @return mixed|null
-     */
-    public function getShadowBaseLanguage()
+    public function getShadowBaseLanguage(): ?string
     {
+        $content = $this->getContent();
+        if ($content instanceof ShadowInterface) {
+            return $content->getShadowLocale();
+        }
+
         return null;
     }
 
     public function getIsShadow(): bool
     {
+        $content = $this->getContent();
+        if ($content instanceof ShadowInterface) {
+            return (bool) $content->getShadowLocale();
+        }
+
         return false;
     }
 

--- a/Tests/Unit/Content/Infrastructure/Sulu/Structure/ContentStructureBridgeTest.php
+++ b/Tests/Unit/Content/Infrastructure/Sulu/Structure/ContentStructureBridgeTest.php
@@ -15,6 +15,7 @@ namespace Sulu\Bundle\ContentBundle\Tests\Unit\Content\Infrastructure\Sulu\Struc
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\ShadowInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\TemplateInterface;
 use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Structure\ContentDocument;
 use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Structure\ContentStructureBridge;
@@ -722,6 +723,39 @@ class ContentStructureBridgeTest extends TestCase
 
     public function testGetIsShadow(): void
     {
+        $structure = $this->createStructureBridge();
+
+        $this->assertFalse($structure->getIsShadow());
+    }
+
+    public function testGetShadowLocalesWithShadowEnabled(): void
+    {
+        $content = $this->prophesize(TemplateInterface::class);
+        $content->willImplement(ShadowInterface::class);
+        $content->getShadowLocales()->shouldBeCalled()->willReturn(['de' => 'en', 'en' => 'en']);
+
+        $structure = $this->createStructureBridge($content->reveal());
+
+        $this->assertSame(['de' => 'en', 'en' => 'en'], $structure->getShadowLocales());
+    }
+
+    public function testGetShadowBaseLanguageWithShadowEnabled(): void
+    {
+        $content = $this->prophesize(TemplateInterface::class);
+        $content->willImplement(ShadowInterface::class);
+        $content->getShadowLocale()->shouldBeCalled()->willReturn('de');
+
+        $structure = $this->createStructureBridge();
+
+        $this->assertNull($structure->getShadowBaseLanguage());
+    }
+
+    public function testGetIsShadowWithShadowEnabled(): void
+    {
+        $content = $this->prophesize(TemplateInterface::class);
+        $content->willImplement(ShadowInterface::class);
+        $content->getShadowLocale()->shouldBeCalled()->willReturn('de');
+
         $structure = $this->createStructureBridge();
 
         $this->assertFalse($structure->getIsShadow());

--- a/Tests/Unit/Content/Infrastructure/Sulu/Structure/ContentStructureBridgeTest.php
+++ b/Tests/Unit/Content/Infrastructure/Sulu/Structure/ContentStructureBridgeTest.php
@@ -15,6 +15,7 @@ namespace Sulu\Bundle\ContentBundle\Tests\Unit\Content\Infrastructure\Sulu\Struc
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ShadowInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\TemplateInterface;
 use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Structure\ContentDocument;
@@ -745,9 +746,9 @@ class ContentStructureBridgeTest extends TestCase
         $content->willImplement(ShadowInterface::class);
         $content->getShadowLocale()->shouldBeCalled()->willReturn('de');
 
-        $structure = $this->createStructureBridge();
+        $structure = $this->createStructureBridge($content->reveal());
 
-        $this->assertNull($structure->getShadowBaseLanguage());
+        $this->assertSame('de', $structure->getShadowBaseLanguage());
     }
 
     public function testGetIsShadowWithShadowEnabled(): void
@@ -756,9 +757,9 @@ class ContentStructureBridgeTest extends TestCase
         $content->willImplement(ShadowInterface::class);
         $content->getShadowLocale()->shouldBeCalled()->willReturn('de');
 
-        $structure = $this->createStructureBridge();
+        $structure = $this->createStructureBridge($content->reveal());
 
-        $this->assertFalse($structure->getIsShadow());
+        $this->assertTrue($structure->getIsShadow());
     }
 
     public function testGetContentLocales(): void
@@ -766,6 +767,16 @@ class ContentStructureBridgeTest extends TestCase
         $structure = $this->createStructureBridge();
 
         $this->assertSame([], $structure->getContentLocales());
+    }
+
+    public function testGetContentLocalesWithDimensionContentInterface(): void
+    {
+        $content = $this->prophesize(TemplateInterface::class);
+        $content->willImplement(DimensionContentInterface::class);
+        $content->getAvailableLocales()->shouldBeCalled()->willReturn(['de', 'en']);
+        $structure = $this->createStructureBridge($content->reveal());
+
+        $this->assertSame(['de', 'en'], $structure->getContentLocales());
     }
 
     public function testGetOriginalTemplate(): void


### PR DESCRIPTION
Adjusts the already existing methods in the `ContentStructureBridge` to use the new shadow logic.