### PR TITLE
Enable preview for shadow entities

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -33,6 +33,7 @@ $config->setRiskyAllowed(true)
         'strict_param' => true,
         'get_class_to_class_keyword' => false, // should be enabled as soon as support for php < 8 is dropped
         'nullable_type_declaration_for_default_null_value' => true,
+        'no_null_property_initialization' => false,
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/Content/Infrastructure/Sulu/Admin/ContentViewBuilderFactory.php
+++ b/Content/Infrastructure/Sulu/Admin/ContentViewBuilderFactory.php
@@ -240,12 +240,6 @@ class ContentViewBuilderFactory implements ContentViewBuilderFactoryInterface
                 $settingsToolbarActions,
                 $dimensionContentClass
             );
-
-            foreach ($views as $view) {
-                if ($view instanceof PreviewFormViewBuilderInterface) {
-                    $view->setPreviewCondition('shadowOn != true');
-                }
-            }
         }
 
         return $views;

--- a/Content/Infrastructure/Sulu/Preview/ContentObjectProvider.php
+++ b/Content/Infrastructure/Sulu/Preview/ContentObjectProvider.php
@@ -196,13 +196,7 @@ class ContentObjectProvider implements PreviewObjectProviderInterface
 
             // unfortunately we can only check if it is a shadow after the dimensionContent was loaded
             if ($resolvedDimensionContent instanceof ShadowInterface && $resolvedDimensionContent->getShadowLocale()) {
-                $resolvedDimensionContent = $this->contentResolver->resolve(
-                    $contentRichEntity,
-                    [
-                        'locale' => $resolvedDimensionContent->getShadowLocale(),
-                        'stage' => DimensionContentInterface::STAGE_DRAFT,
-                    ]
-                );
+                return $this->resolveContent($contentRichEntity, $resolvedDimensionContent->getShadowLocale());
             }
 
             if (!$resolvedDimensionContent->getLocale()) {

--- a/Content/Infrastructure/Sulu/Preview/ContentObjectProvider.php
+++ b/Content/Infrastructure/Sulu/Preview/ContentObjectProvider.php
@@ -20,6 +20,7 @@ use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\ContentResolve
 use Sulu\Bundle\ContentBundle\Content\Domain\Exception\ContentNotFoundException;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentRichEntityInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\ShadowInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\TemplateInterface;
 use Sulu\Bundle\PreviewBundle\Preview\Object\PreviewObjectProviderInterface;
 
@@ -192,6 +193,17 @@ class ContentObjectProvider implements PreviewObjectProviderInterface
                     'stage' => DimensionContentInterface::STAGE_DRAFT,
                 ]
             );
+
+            // unfortunately we can only check if it is a shadow after the dimensionContent was loaded
+            if ($resolvedDimensionContent instanceof ShadowInterface && $resolvedDimensionContent->getShadowLocale()) {
+                $resolvedDimensionContent = $this->contentResolver->resolve(
+                    $contentRichEntity,
+                    [
+                        'locale' => $resolvedDimensionContent->getShadowLocale(),
+                        'stage' => DimensionContentInterface::STAGE_DRAFT,
+                    ]
+                );
+            }
 
             if (!$resolvedDimensionContent->getLocale()) {
                 // avoid 500 error when ghostLocale is loaded by still use correct locale in serialize method

--- a/Tests/Unit/Content/Infrastructure/Sulu/Preview/ContentObjectProviderTest.php
+++ b/Tests/Unit/Content/Infrastructure/Sulu/Preview/ContentObjectProviderTest.php
@@ -154,7 +154,7 @@ class ContentObjectProviderTest extends TestCase
             $entity->reveal(),
             [
                 'locale' => 'de',
-                'stage' => DimensionContentInterface::STAGE_DRAFT
+                'stage' => DimensionContentInterface::STAGE_DRAFT,
             ]
         )->willReturn($dimensionContent->reveal())->shouldBeCalledTimes(1);
 
@@ -164,7 +164,7 @@ class ContentObjectProviderTest extends TestCase
             $entity->reveal(),
             [
                 'locale' => 'en',
-                'stage' => DimensionContentInterface::STAGE_DRAFT
+                'stage' => DimensionContentInterface::STAGE_DRAFT,
             ]
         )->willReturn($dimensionContent->reveal())->shouldBeCalledTimes(1);
 


### PR DESCRIPTION
This PR removes the preview condition for shadowlocales and adds a temporary solution for the preview.

This solution is not really good, as we need to load the dimensionContent twice for shadowLocales, but it should be sufficient for now.