### PR TITLE
Fix Upgrade.md file version headline

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -102,8 +102,6 @@ The `DataMapperInterface` was changed to make it easier to set localized and unl
     ): void;
 ```
 
-## 0.6.x
-
 ### Use jsonb for PostgreSQL json columns
 
 This effects only PostgreSQL databases:


### PR DESCRIPTION
This part was never released as 0.6.x it was part of 0.7.