### PR TITLE
Querying a relationship should be done through the entity not the id

### DIFF
--- a/Content/Infrastructure/Doctrine/DimensionContentRepository.php
+++ b/Content/Infrastructure/Doctrine/DimensionContentRepository.php
@@ -66,7 +66,7 @@ class DimensionContentRepository implements DimensionContentRepositoryInterface
         $queryBuilder = $this->entityManager->createQueryBuilder()
             ->from($dimensionContentClass, 'dimensionContent')
             ->where('dimensionContent.' . $mappingProperty . ' = :id')
-            ->setParameter('id', $contentRichEntity->getId());
+            ->setParameter('id', $contentRichEntity);
 
         $this->dimensionContentQueryEnhancer->addSelects(
             $queryBuilder,


### PR DESCRIPTION
## Why?

1. If you try to use this with a newly created entity the Id of the entity is null. Null however is not allowed in the interface of the `DimensionContentInterface` (which I think is correct). Then the only way to do it correctly is leave it uninitialized and then the program crashes. However if we just hand off the handling to doctrine, it's going to use it's magic to get the value of the property directly
2. If you use the object it's going to use the primary identifier specified in the metadata of that entity. If you had a different primary key than id (I know not a common use case) but this should work now too.