### PR TITLE
Decorate structure resolver to support AuthorInterface

### DIFF
--- a/Content/Application/StructureResolver/DecoratedStructureResolver.php
+++ b/Content/Application/StructureResolver/DecoratedStructureResolver.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Content\Application\StructureResolver;
+
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\AuthorInterface;
+use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Structure\ContentDocument;
+use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Structure\ContentStructureBridge;
+use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolverInterface;
+use Sulu\Component\Content\Compat\StructureInterface;
+
+class DecoratedStructureResolver implements StructureResolverInterface
+{
+    public function __construct(private StructureResolverInterface $inner)
+    {
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function resolve(StructureInterface $structure, bool $loadExcerpt = true): array
+    {
+        $data = $this->inner->resolve($structure, $loadExcerpt);
+
+        if (!$structure instanceof ContentStructureBridge) {
+            return $data;
+        }
+
+        /** @var ContentDocument $document */
+        $document = $structure->getDocument();
+        $content = $document->getContent();
+
+        if ($content instanceof AuthorInterface) {
+            $data['authored'] = $content->getAuthored();
+            $data['author'] = $content->getAuthor()?->getId();
+        }
+
+        return $data;
+    }
+}

--- a/Content/Infrastructure/Sulu/Structure/DecoratedStructureResolver.php
+++ b/Content/Infrastructure/Sulu/Structure/DecoratedStructureResolver.php
@@ -17,6 +17,9 @@ use Sulu\Bundle\ContentBundle\Content\Domain\Model\AuthorInterface;
 use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolverInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
 
+/**
+ * @internal
+ */
 class DecoratedStructureResolver implements StructureResolverInterface
 {
     public function __construct(private StructureResolverInterface $inner)

--- a/Content/Infrastructure/Sulu/Structure/DecoratedStructureResolver.php
+++ b/Content/Infrastructure/Sulu/Structure/DecoratedStructureResolver.php
@@ -11,11 +11,9 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\ContentBundle\Content\Application\StructureResolver;
+namespace Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Structure;
 
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\AuthorInterface;
-use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Structure\ContentDocument;
-use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Structure\ContentStructureBridge;
 use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolverInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -191,5 +191,10 @@
         </service>
 
         <service id="Sulu\Bundle\ContentBundle\Content\Application\ContentManager\ContentManagerInterface" alias="sulu_content.content_manager"/>
+
+        <!-- StructureResolver -->
+        <service id="Sulu\Bundle\ContentBundle\Content\Application\StructureResolver\DecoratedStructureResolver" decorates="sulu_website.resolver.structure">
+            <argument type="service" id=".inner"/>
+        </service>
     </services>
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -193,7 +193,7 @@
         <service id="Sulu\Bundle\ContentBundle\Content\Application\ContentManager\ContentManagerInterface" alias="sulu_content.content_manager"/>
 
         <!-- StructureResolver -->
-        <service id="Sulu\Bundle\ContentBundle\Content\Application\StructureResolver\DecoratedStructureResolver" decorates="sulu_website.resolver.structure">
+        <service id="Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Structure\DecoratedStructureResolver" decorates="sulu_website.resolver.structure">
             <argument type="service" id=".inner"/>
         </service>
     </services>

--- a/Tests/Unit/Content/Infrastructure/Sulu/Structure/DecoratedStructureResolverTest.php
+++ b/Tests/Unit/Content/Infrastructure/Sulu/Structure/DecoratedStructureResolverTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Tests\Unit\Content\Infrastructure\Sulu\Structure;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\AuthorInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\TemplateInterface;
+use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Structure\ContentDocument;
+use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Structure\ContentStructureBridge;
+use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Structure\DecoratedStructureResolver;
+use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolverInterface;
+use Sulu\Component\Content\Compat\StructureInterface;
+
+class DecoratedStructureResolverTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<StructureResolverInterface>
+     */
+    private $innerResolver;
+
+    /**
+     * @var DecoratedStructureResolver
+     */
+    private $decoratedResolver;
+
+    protected function setUp(): void
+    {
+        $this->innerResolver = $this->prophesize(StructureResolverInterface::class);
+        $this->decoratedResolver = new DecoratedStructureResolver($this->innerResolver->reveal());
+    }
+
+    public function testResolveWithNonContentStructureBridge(): void
+    {
+        $structure = $this->prophesize(StructureInterface::class);
+        $expectedData = ['key' => 'value'];
+
+        $this->innerResolver->resolve($structure->reveal(), true)
+            ->willReturn($expectedData);
+
+        $result = $this->decoratedResolver->resolve($structure->reveal());
+
+        $this->assertSame($expectedData, $result);
+    }
+
+    public function testResolveWithContentStructureBridgeNonAuthorInterface(): void
+    {
+        $structure = $this->prophesize(ContentStructureBridge::class);
+        $document = $this->prophesize(ContentDocument::class);
+        $content = $this->prophesize(TemplateInterface::class);
+
+        $structure->getDocument()->willReturn($document->reveal());
+        $document->getContent()->willReturn($content);
+
+        $expectedData = ['key' => 'value'];
+        $this->innerResolver->resolve($structure->reveal(), true)
+            ->willReturn($expectedData);
+
+        $result = $this->decoratedResolver->resolve($structure->reveal());
+
+        $this->assertSame($expectedData, $result);
+    }
+
+    public function testResolveWithContentStructureBridgeAndAuthorInterface(): void
+    {
+        $structure = $this->prophesize(ContentStructureBridge::class);
+        $document = $this->prophesize(ContentDocument::class);
+        $content = $this->prophesize(TemplateInterface::class);
+        $content->willImplement(AuthorInterface::class);
+        $author = $this->prophesize(ContactInterface::class);
+
+        $structure->getDocument()->willReturn($document->reveal());
+        $document->getContent()->willReturn($content->reveal());
+
+        $expectedData = ['key' => 'value'];
+        $this->innerResolver->resolve($structure->reveal(), true)
+            ->willReturn($expectedData);
+
+        $authDate = new \DateTimeImmutable();
+        $content->getAuthored()->willReturn($authDate);
+        $content->getAuthor()->willReturn($author->reveal());
+        $author->getId()->willReturn(123);
+
+        $result = $this->decoratedResolver->resolve($structure->reveal());
+
+        $expectedResult = \array_merge($expectedData, [
+            'authored' => $authDate,
+            'author' => 123,
+        ]);
+
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public function testResolveWithContentStructureBridgeAndAuthorInterfaceNoAuthor(): void
+    {
+        $structure = $this->prophesize(ContentStructureBridge::class);
+        $document = $this->prophesize(ContentDocument::class);
+        $content = $this->prophesize(TemplateInterface::class);
+        $content->willImplement(AuthorInterface::class);
+
+        $structure->getDocument()->willReturn($document->reveal());
+        $document->getContent()->willReturn($content->reveal());
+
+        $expectedData = ['key' => 'value'];
+        $this->innerResolver->resolve($structure->reveal(), true)
+            ->willReturn($expectedData);
+
+        $content->getAuthored()->willReturn(null);
+        $content->getAuthor()->willReturn(null);
+
+        $result = $this->decoratedResolver->resolve($structure->reveal());
+
+        $expectedResult = \array_merge($expectedData, [
+            'authored' => null,
+            'author' => null,
+        ]);
+
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public function testResolveWithExcerptFlag(): void
+    {
+        $structure = $this->prophesize(StructureInterface::class);
+        $expectedData = ['key' => 'value'];
+
+        $this->innerResolver->resolve($structure->reveal(), false)
+            ->willReturn($expectedData);
+
+        $result = $this->decoratedResolver->resolve($structure->reveal(), false);
+
+        $this->assertSame($expectedData, $result);
+    }
+}


### PR DESCRIPTION
Sulu core uses the [StructureResolver](https://github.com/sulu/sulu/blob/2.6/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php#L115-L118) to set `author` and `authored`

This is not working for the contentbundle, because the DimensionContent entity does not use the `LocalizedAuthorBehavior` interface, but instead the `AuthorInterface` of the content bundle directly.

This MR decorates the original resolver to also support the contentBundle dimensions.